### PR TITLE
Github Actions Setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,5 +17,5 @@ USER ubuntu
 
 RUN git clone --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 RUN cd linux && \
-    make defconfig O=kernel-build && \
-    make -j$(nproc) O=kernel-build
+    make defconfig O=kernel_build && \
+    make -j$(nproc) O=kernel_build

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+
+## CMD Graph Based Kernel Builds
+
+This manually triggered workflow downloads a Linux kernel archive from:
+
+https://fileshare.tngtech.com/d/e69946da808b41f88047/
+
+The archive includes:
+- The full Linux source tree
+- A `kernel_build` directory with build output and `.config` used for the build
+
+The workflow reconstructs a minimal source tree using only source files from the CMD graph and rebuilds the kernel using the original config.
+
+Note: To add new test data to the library, build the Linux kernel using a specific configuration as follows:
+```bash
+cd linux
+make <config_name> O=kernel_build
+make -j$(nproc) O=kernel_build
+cd ..
+tar -czf linux-<config_name>.tar.gz linux
+```

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v4
+      
+      - name: RUFF
+        uses: astral-sh/ruff-action@v3
+      
+      - name: Tests
+        run: python3 -m unittest discover -v -s sbom/lib -p "test_*.py"

--- a/.github/workflows/cmd_graph_based_kernel_build.yaml
+++ b/.github/workflows/cmd_graph_based_kernel_build.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+name: CMD Graph Based Kernel Builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_archive:
+        description: 'Name of the test archive to download from https://fileshare.tngtech.com/d/e69946da808b41f88047/'
+        required: false
+        default: 'linux-defconfig.tar.gz'
+      freeDiskSpace:
+        type: boolean
+        default: false
+        description: whether to free disk space before building the kernel
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ inputs.freeDiskSpace }}
+
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies and Linux Kernel
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+              build-essential linux-image-generic linux-headers-generic bc \
+              flex bison python3 python3-pip python3-venv git libelf-dev libssl-dev
+
+      - name: Download Linux Kernel Test Data
+        run: |
+          test_archive="${{ inputs.test_archive }}"
+          echo "Downloading $test_archive"
+          curl -L -o "$test_archive" "https://fileshare.tngtech.com/d/e69946da808b41f88047/files/?p=%2F$test_archive&dl=1"
+          tar -xzf "$test_archive"
+          rm "$test_archive"
+
+      # Create the linux_cmd directory which contains only source files referenced in the cmd graph
+      - name: Create linux_cmd
+        run: python3 sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
+
+      # Build kernel with the original .config using only source files referenced in the cmd graph
+      - name: Cmd Graph Based Kernel Build
+        run: |
+          cd linux_cmd
+          mkdir kernel_build
+          cp ../linux/kernel_build/.config kernel_build/.config
+          make olddefconfig O=kernel_build
+          make -j$(nproc) O=kernel_build

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 .venv
 __pycache__
 sbom.spdx.json
-linux-cmd
+linux_cmd
 linux

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ docker compose up
 This will:
 - Build a Docker image based on the included [Dockerfile](./Dockerfile).
 - Clone the Linux kernel repository during the image build.
-- Compile the kernel out-of-tree into `linux/kernel-build`.
+- Compile the kernel out-of-tree into `linux/kernel_build`.
 - Start a container with this repository mounted as volume.
 - Run the [sbom.py](sbom/sbom.py) script inside the container:
   ```bash
   python3 sbom/sbom.py \
     --src-tree ../linux \
-    --output-tree ../linux/kernel-build \
+    --output-tree ../linux/kernel_build \
     --root-output-in-tree vmlinux \
     --output sbom.spdx.json
   ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,6 @@ services:
     command: >
       python3 src/sbom.py
         --src-tree ../linux
-        --output-tree ../linux/kernel-build
+        --output-tree ../linux/kernel_build
         --root-output-in-tree vmlinux
         --output sbom.spdx.json

--- a/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
+++ b/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
@@ -5,7 +5,7 @@
 from pathlib import Path
 import unittest
 
-from lib.sbom.cmd.savedcmd_parser import parse_commands
+from sbom.cmd.savedcmd_parser import parse_commands
 
 
 class TestSavedCmdParser(unittest.TestCase):

--- a/sbom/sbom.py
+++ b/sbom/sbom.py
@@ -37,8 +37,8 @@ def parse_args() -> Args:
     )
     parser.add_argument(
         "--output-tree",
-        default="../linux/kernel-build",
-        help="Path to the build output tree directory (default: ../linux/kernel-build)",
+        default="../linux/kernel_build",
+        help="Path to the build output tree directory (default: ../linux/kernel_build)",
     )
     parser.add_argument(
         "--root-output-in-tree",

--- a/sbom_analysis/cmd_graph_based_kernel_build/README.md
+++ b/sbom_analysis/cmd_graph_based_kernel_build/README.md
@@ -8,14 +8,14 @@ SPDX-License-Identifier: GPL-2.0-only
 
 The script [`cmd_graph_based_kernel_build.py`](./cmd_graph_based_kernel_build.py) validates the completeness of the cmd graph — i.e., whether it includes all source files required to build the Linux kernel.
 
-It does this by reconstructing a minimal Linux source tree under `linux-cmd/`. The script copies the original `linux` source tree and removes any source files **not** referenced in the cmd graph. If the kernel builds successfully from this pruned tree, it confirms that the cmd graph includes all necessary files.
+It does this by reconstructing a minimal Linux source tree under `linux_cmd/`. The script copies the original `linux` source tree and removes any source files **not** referenced in the cmd graph. If the kernel builds successfully from this pruned tree, it confirms that the cmd graph includes all necessary files.
 
 To run the validation:
 
 ```bash
 python sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
-cd linux-cmd
-make defconfig O=kernel-build
-make -j$(nproc) O=kernel-build
+cd linux_cmd
+make defconfig O=kernel_build
+make -j$(nproc) O=kernel_build
 ```
 > **Note:** The script assumes that the `linux` source tree lies within this repository. You get this layout by default when using the [devcontainer](../.devcontainer/devcontainer.json).

--- a/sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
+++ b/sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
@@ -47,7 +47,6 @@ def _remove_files(base_path: Path, patterns_to_remove: list[re.Pattern[str]], ig
         ):
             continue
 
-        logging.info(f"Delete {file_path}")
         file_path.unlink()
         removed_files.append(file_path)
     return removed_files
@@ -58,14 +57,14 @@ if __name__ == "__main__":
     # Paths to the original source and build directories
     cmd_graph_path = script_path / "cmd_graph.pickle"
     src_tree = (script_path / "../../linux").resolve()
-    output_tree = (script_path / "../../linux/kernel-build").resolve()
+    output_tree = (script_path / "../../linux/kernel_build").resolve()
     root_output_in_tree = Path("vmlinux")
 
     # Configure logging
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
     # Copy the original source tree
-    cmd_src_tree = (script_path / "../../linux-cmd").resolve()
+    cmd_src_tree = (script_path / "../../linux_cmd").resolve()
     if cmd_src_tree.exists():
         shutil.rmtree(cmd_src_tree)
     logging.info(f"Copy {src_tree} into {cmd_src_tree}")
@@ -76,6 +75,7 @@ if __name__ == "__main__":
         logging.info("Load cmd graph")
         cmd_graph = load_cmd_graph(cmd_graph_path)
     else:
+        logging.info("Build cmd graph")
         cmd_graph = build_cmd_graph(root_output_in_tree, output_tree, src_tree)
         save_cmd_graph(cmd_graph, cmd_graph_path)
 

--- a/sbom_analysis/cmd_graph_visualization/cmd_graph_visualization.py
+++ b/sbom_analysis/cmd_graph_visualization/cmd_graph_visualization.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     script_path = Path(__file__).parent
     cmd_graph_path = script_path / "cmd_graph.pickle"
     src_tree = (script_path / "../../linux").resolve()
-    output_tree = (script_path / "../../linux/kernel-build").resolve()
+    output_tree = (script_path / "../../linux/kernel_build").resolve()
     root_output_in_tree = Path("vmlinux")
     cmd_graph_json_gz_path = script_path / "web/cmd_graph.json.gz"
     max_visualization_depth: int | None = None


### PR DESCRIPTION
adds two new github workflows
- **CI** includes reuse, ruff and unittesting
- **CMD Graph Based Kernel Build** manually triggered workflow to to validate that (i) the cmd graph can be build for different output trees and (ii) the cmd graph is complete in a sense that the only the source files in the cmd graph are required to build the kernel with the given configuration.  
  [Successful test run with defconfig](https://github.com/TNG/KernelSbom/actions/runs/18127503472/job/51586019193). Where defconfig is downloaded from [TNG FileShare](https://fileshare.tngtech.com/d/e69946da808b41f88047/)