### PR TITLE
sbom.py: use correct SPDX kernel format

### DIFF
--- a/sbom/sbom.py
+++ b/sbom/sbom.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 """
 Compute software bill of materials in SPDX format describing a kernel build.


### PR DESCRIPTION
SPDX license lines go on the first line non-#! line in a file in the kernel source tree, so move the SPDX-License-Identifier to that place.

Should also be done for all files in this directory, but I figured I'd do one first to verify this works :)