### PR TITLE
License header template

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 -->
 
 ## CMD Graph Based Kernel Builds

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 name: CI
 

--- a/.github/workflows/cmd_graph_based_kernel_build.yaml
+++ b/.github/workflows/cmd_graph_based_kernel_build.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 name: CMD Graph Based Kernel Builds
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 .venv
 __pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 repos:
   - repo: https://github.com/fsfe/reuse-tool

--- a/.reuse/templates/default.jinja2
+++ b/.reuse/templates/default.jinja2
@@ -1,0 +1,9 @@
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for contributor_line in contributor_lines %}
+SPDX-FileContributor: {{ contributor_line }}
+{% endfor %}

--- a/.vscode/launch.json.license
+++ b/.vscode/launch.json.license
@@ -1,3 +1,2 @@
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH

--- a/.vscode/settings.json.license
+++ b/.vscode/settings.json.license
@@ -1,3 +1,2 @@
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH

--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ when commiting `reuse lint` is executed as a pre-commit hook to check if all fil
 ```
 reuse annotate --license="GPL-2.0-only" --copyright="TNG Technology Consulting GmbH" --template default <filename>
 ```
+>**Note:** if the annotated file contains a shebang `reuse annotate` will add an empty line after the shebang. This empty line needs to be removed manually.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 -->
 
 # KernelSbom
@@ -60,5 +59,5 @@ The main contribution is the content of the `sbom` directory which eventually sh
 
 when commiting `reuse lint` is executed as a pre-commit hook to check if all files have compliant License headers. If any file is missing a license header add it via 
 ```
-reuse annotate --license="GPL-2.0-only" --copyright="TNG Technology Consulting GmbH" <filename>
+reuse annotate --license="GPL-2.0-only" --copyright="TNG Technology Consulting GmbH" --template default <filename>
 ```

--- a/sbom/lib/sbom/cmd/cmd_file_parser.py
+++ b/sbom/lib/sbom/cmd/cmd_file_parser.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 import re
 from pathlib import Path

--- a/sbom/lib/sbom/cmd/cmd_graph.py
+++ b/sbom/lib/sbom/cmd/cmd_graph.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 
 import logging

--- a/sbom/lib/sbom/cmd/deps_parser.py
+++ b/sbom/lib/sbom/cmd/deps_parser.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 from pathlib import Path
 import re

--- a/sbom/lib/sbom/cmd/savedcmd_parser.py
+++ b/sbom/lib/sbom/cmd/savedcmd_parser.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 from pathlib import Path
 import re

--- a/sbom/lib/sbom/spdx.py
+++ b/sbom/lib/sbom/spdx.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone

--- a/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
+++ b/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 from pathlib import Path
 import unittest

--- a/sbom/sbom.py
+++ b/sbom/sbom.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
+
 
 """
 Compute software bill of materials in SPDX format describing a kernel build.

--- a/sbom/sbom.py
+++ b/sbom/sbom.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 

--- a/sbom_analysis/.gitignore
+++ b/sbom_analysis/.gitignore
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 cmd_graph.pickle
 cmd_graph.json.gz

--- a/sbom_analysis/cmd_graph_based_kernel_build/README.md
+++ b/sbom_analysis/cmd_graph_based_kernel_build/README.md
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 -->
 
 # CMD Graph-Based Kernel Build

--- a/sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
+++ b/sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 

--- a/sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
+++ b/sbom_analysis/cmd_graph_based_kernel_build/cmd_graph_based_kernel_build.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 import json
 import logging

--- a/sbom_analysis/cmd_graph_visualization/README.md
+++ b/sbom_analysis/cmd_graph_visualization/README.md
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 -->
 
 # CMD Graph Visualization

--- a/sbom_analysis/cmd_graph_visualization/cmd_graph_visualization.py
+++ b/sbom_analysis/cmd_graph_visualization/cmd_graph_visualization.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 from dataclasses import asdict, dataclass
 import json

--- a/sbom_analysis/cmd_graph_visualization/cmd_graph_visualization.py
+++ b/sbom_analysis/cmd_graph_visualization/cmd_graph_visualization.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 

--- a/sbom_analysis/cmd_graph_visualization/vmlinux-no-headers-no-configs.png.license
+++ b/sbom_analysis/cmd_graph_visualization/vmlinux-no-headers-no-configs.png.license
@@ -1,3 +1,2 @@
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH

--- a/sbom_analysis/cmd_graph_visualization/web/index.html
+++ b/sbom_analysis/cmd_graph_visualization/web/index.html
@@ -1,9 +1,8 @@
 <!--
+SPDX-License-Identifier: GPL-2.0-only
+SPDX-License-Identifier: MIT
 SPDX-FileCopyrightText: (c) 2018 Vasco Asturiano
 SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
-SPDX-License-Identifier: MIT
-SPDX-License-Identifier: GPL-2.0-only
 -->
 
 <head>

--- a/testdata_generation/Dockerfile
+++ b/testdata_generation/Dockerfile
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-#
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 FROM ubuntu:22.04
 

--- a/testdata_generation/README.md
+++ b/testdata_generation/README.md
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
-
 SPDX-License-Identifier: GPL-2.0-only
+SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 -->
 
 # Test Data Generation

--- a/testdata_generation/extract_testdata.sh
+++ b/testdata_generation/extract_testdata.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
 

--- a/testdata_generation/extract_testdata.sh
+++ b/testdata_generation/extract_testdata.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
-#
+
 # SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: Maximilian Huber <maximilian.huber@tngtech.com>
 
 set -euo pipefail
 


### PR DESCRIPTION
This PR introduces a license header template at `.reuse/templates/default.jinja2` to make `reuse annotate` generate headers conforming to the conventions used in the Linux kernel.