### PR TITLE
Extend command parsers for Rust Defconfig

### DIFF
--- a/sbom/lib/sbom/cmd/savedcmd_parser.py
+++ b/sbom/lib/sbom/cmd/savedcmd_parser.py
@@ -55,7 +55,7 @@ def _tokenize_single_command(command: str, flag_options: list[str] | None = None
             continue
 
         # Option without value (--flag)
-        if flag_options and token in flag_options:
+        if token.startswith("-") and tokens[i + 1].startswith("-") or (flag_options and token in flag_options):
             parsed.append(Option(name=token))
             i += 1
             continue
@@ -89,7 +89,7 @@ def _tokenize_single_command_positionals_only(command: str) -> list[str]:
 
 
 def _parse_objcopy_command(command: str) -> list[Path]:
-    command_parts = _tokenize_single_command(command, flag_options=["-S"])
+    command_parts = _tokenize_single_command(command, flag_options=["-S", "-w"])
     positionals = [part.value for part in command_parts if isinstance(part, Positional)]
     # expect positionals to be ['objcopy', input_file] or ['objcopy', input_file, output_file]
     if not (len(positionals) == 2 or len(positionals) == 3):
@@ -200,7 +200,7 @@ def _parse_sed_command(command: str) -> list[Path]:
 
 # Command parser registry
 SINGLE_COMMAND_PARSERS: list[tuple[re.Pattern[str], Callable[[str], list[Path]]]] = [
-    (re.compile(r"^objcopy\b"), _parse_objcopy_command),
+    (re.compile(r"^(llvm-)?objcopy\b"), _parse_objcopy_command),
     (re.compile(r"^(.*/)?link-vmlinux\.sh\b"), _parse_link_vmlinux_command),
     (re.compile(r"^rm\b"), _parse_noop),
     (re.compile(r"^mkdir\b"), _parse_noop),

--- a/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
+++ b/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
@@ -15,6 +15,16 @@ class TestSavedCmdParser(unittest.TestCase):
         expected = [Path("vmlinux.unstripped")]
         self.assertEqual(parse_commands(cmd), expected)
 
+    def test_objcopy_llvm(self):
+        cmd = "llvm-objcopy --remove-section='.rel*' --remove-section=!'.rel*.dyn' vmlinux.unstripped vmlinux"
+        expected = [Path("vmlinux.unstripped")]
+        self.assertEqual(parse_commands(cmd), expected)
+
+    def test_objcopy_no_output(self):
+        cmd = "objcopy -w -W '__*' rust/compiler_builtins.o"
+        expected = [Path("rust/compiler_builtins.o")]
+        self.assertEqual(parse_commands(cmd), expected)
+
     # link-vmlinux.sh command tests
 
     def test_link_vmlinux(self):

--- a/sbom/sbom.py
+++ b/sbom/sbom.py
@@ -139,9 +139,20 @@ def main():
 
     # Save used files
     if args.used_files != "none":
-        logging.info("Extracting source files from cmd graph")
-        used_files = [node.absolute_path.relative_to(src_tree) for node in iter_cmd_graph(cmd_graph) if node.is_source]
-        logging.info(f"Found {len(used_files)} source files in cmd graph.")
+        if src_tree == output_tree:
+            logging.warning(
+                "Cannot distinguish source and output files because source and output tree are equal. Extracting all files from cmd graph"
+            )
+            used_files = [
+                os.path.relpath(node.absolute_path, src_tree)
+                for node in iter_cmd_graph(cmd_graph)
+                if node.absolute_path.is_relative_to(src_tree) and not node.absolute_path.is_relative_to(output_tree)
+            ]
+            logging.info(f"Found {len(used_files)} source files in cmd graph.")
+        else:
+            logging.info("Extracting source files from cmd graph")
+            used_files = [os.path.relpath(node.absolute_path, src_tree) for node in iter_cmd_graph(cmd_graph)]
+            logging.info(f"Found {len(used_files)} files in cmd graph.")
         with open(args.used_files, "w", encoding="utf-8") as f:
             f.write("\n".join(str(file_path) for file_path in used_files))
         logging.info(f"Saved {args.used_files} successfully")


### PR DESCRIPTION
This PR extends command parsers to successfully build the cmd graph for [linux.v6.17.defconfig.rust.tar.gz](https://fileshare.tngtech.com/d/e69946da808b41f88047/).