### PR TITLE
Make test environment more similar to build environment

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Download ${{ inputs.test_archive }}
         run: |
-          cd ..
+          sudo mkdir /workspace
+          sudo chown $USER:$USER /workspace
+          cd /workspace
           test_archive="${{ inputs.test_archive }}"
           echo "Downloading $test_archive"
           curl -L -o "$test_archive" "https://fileshare.tngtech.com/d/e69946da808b41f88047/files/?p=%2F$test_archive&dl=1"
@@ -66,7 +68,7 @@ jobs:
           
           if [ "${{ inputs.use_modules }}" = "true" ]; then
             python3 sbom_analysis/module_roots.py \
-              ../linux/${{ inputs.output_tree }}/modules.order \
+              /workspace/linux/${{ inputs.output_tree }}/modules.order \
               module_roots.txt
             cat module_roots.txt >> roots.txt
           fi
@@ -80,8 +82,8 @@ jobs:
           export SRCARCH="${{ inputs.arch }}"
 
           python3 sbom/sbom.py \
-            --src-tree ../linux \
-            --output-tree ../linux/${{ inputs.output_tree }} \
+            --src-tree /workspace/linux \
+            --output-tree /workspace/linux/${{ inputs.output_tree }} \
             --roots-file roots.txt \
             --spdx sbom.spdx.json \
             --used-files sbom.used_files.txt

--- a/.github/workflows/sbom_all_configs.yaml
+++ b/.github/workflows/sbom_all_configs.yaml
@@ -44,5 +44,5 @@ jobs:
           - test_archive: linux.v6.17.allmodconfig.x86.tar.gz
           # - test_archive: linux.v6.17.localmodconfig.Ubuntu24.04.x86.tar.gz
           - test_archive: linux.v6.17.y.gregkh-linux-stable.x86.tar.gz
-          - test_archive: linux.v6.17.y.gregkh-linux-stable.arm64.rust.tar.gz
-            arch: arm64
+          # - test_archive: linux.v6.17.y.gregkh-linux-stable.arm64.rust.tar.gz
+          #   arch: arm64

--- a/sbom/lib/sbom/cmd/savedcmd_parser.py
+++ b/sbom/lib/sbom/cmd/savedcmd_parser.py
@@ -390,6 +390,12 @@ def _parse_dtc_command(command: str) -> list[Path]:
     return [Path(positionals[1])]
 
 
+def _parse_bindgen_command(command: str) -> list[Path]:
+    command_parts = shlex.split(command)
+    header_file_input_paths = [part for part in command_parts if part.endswith(".h")]
+    return [Path(p) for p in header_file_input_paths]
+
+
 # Command parser registry
 SINGLE_COMMAND_PARSERS: list[tuple[re.Pattern[str], Callable[[str], list[Path]]]] = [
     (re.compile(r"\(.*?\)\s*>", re.DOTALL), _parse_compound_command),
@@ -416,6 +422,7 @@ SINGLE_COMMAND_PARSERS: list[tuple[re.Pattern[str], Callable[[str], list[Path]]]
     (re.compile(r"^(.*/)?mkcpustr\s+>"), _parse_noop),
     (re.compile(r"^ld\b"), _parse_ld_command),
     (re.compile(r"^sed.*?>"), lambda c: _parse_sed_command(c.split(">")[0])),
+    (re.compile(r"^sed\b"), _parse_noop),
     (re.compile(r"^(.*/)?objtool\b"), _parse_noop),
     (re.compile(r"^(llvm-)?nm\b.*?\|"), _parse_nm_piped_command),
     (re.compile(r"^(.*/)?pnmtologo\b"), _parse_pnm_to_logo_command),
@@ -437,6 +444,7 @@ SINGLE_COMMAND_PARSERS: list[tuple[re.Pattern[str], Callable[[str], list[Path]]]
     (re.compile(r"^(.*/)?scripts/dtc/dtc\b"), _parse_dtc_command),
     (re.compile(r"^(.*/)?module/gen_test_kallsyms.sh"), _parse_noop),
     (re.compile(r"^openssl\s+req.*?-new.*?-keyout"), _parse_noop),
+    (re.compile(r"bindgen\b"), _parse_bindgen_command),
 ]
 
 # If Block pattern to match a simple, single-level if-then-fi block. Nested If blocks are not supported.

--- a/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
+++ b/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
@@ -360,6 +360,20 @@ class TestSavedCmdParser(unittest.TestCase):
         expected = ""
         self._assert_parsing(cmd, expected)
 
+    # bindgen command tests
+    def test_bindgen(self):
+        cmd = (
+            "bindgen ../rust/bindings/bindings_helper.h "
+            "--blocklist-type __kernel_s?size_t --blocklist-type __kernel_ptrdiff_t "
+            "--opaque-type xregs_state --opaque-type desc_struct --no-doc-comments "
+            "--rust-target 1.68 --use-core --with-derive-default -o rust/bindings/bindings_generated.rs "
+            "-- -Wp,-MMD,rust/bindings/.bindings_generated.rs.d -nostdinc -I../arch/x86/include "
+            "-include ../include/linux/compiler-version.h -D__KERNEL__ -fintegrated-as -fno-builtin -DMODULE; "
+            "sed -Ei 's/pub const RUST_CONST_HELPER_([a-zA-Z0-9_]*)/pub const \\1/g' rust/bindings/bindings_generated.rs"
+        )
+        expected = "../rust/bindings/bindings_helper.h ../include/linux/compiler-version.h"
+        self._assert_parsing(cmd, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Apparently some rust cmd files contain absolute paths to files in the output tree.
This PR changes the download directory of the kernel build testcases to `/workspace/linux` which is the directory in which the testcases were created. This way the absolute paths from the build environment exist in the test environment. 
Also added missing command parser.