### PR TITLE
Replace Path objects with str

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -8,7 +8,7 @@ on:
     inputs:
       test_archive:
         description: Name of the test archive to download from https://fileshare.tngtech.com/d/e69946da808b41f88047/
-        default: linux.v6.17.tinyconfig.tar.gz
+        default: linux.v6.17.tinyconfig.x86.tar.gz
       output_tree: 
         description: Path to the output tree relative to the src tree
         default: kernel_build

--- a/sbom/lib/sbom/cmd/cmd_file_parser.py
+++ b/sbom/lib/sbom/cmd/cmd_file_parser.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 import re
-from pathlib import Path
 from dataclasses import dataclass, field
 import sbom.errors as sbom_errors
+from sbom.path_utils import PathStr
 
 SAVEDCMD_PATTERN = re.compile(r"^(saved)?cmd_.*?:=\s*(?P<full_command>.+)$")
 SOURCE_PATTERN = re.compile(r"^source.*?:=\s*(?P<source_file>.+)$")
@@ -12,14 +12,14 @@ SOURCE_PATTERN = re.compile(r"^source.*?:=\s*(?P<source_file>.+)$")
 
 @dataclass
 class CmdFile:
-    cmd_file_path: Path
+    cmd_file_path: PathStr
     savedcmd: str
-    source: Path | None = None
+    source: PathStr | None = None
     deps: list[str] = field(default_factory=list[str])
     make_rules: list[str] = field(default_factory=list[str])
 
 
-def parse_cmd_file(cmd_file_path: Path) -> CmdFile | None:
+def parse_cmd_file(cmd_file_path: PathStr) -> CmdFile | None:
     """
     Parses a .cmd file.
     .cmd files can have the following structures:
@@ -70,7 +70,7 @@ def parse_cmd_file(cmd_file_path: Path) -> CmdFile | None:
     if line1 is None:
         sbom_errors.log(f"Skip parsing '{cmd_file_path}' because no 'source_' entry was found.")
         return CmdFile(cmd_file_path, savedcmd)
-    source = Path(line1.group("source_file"))
+    source = line1.group("source_file")
 
     # deps
     deps: list[str] = []

--- a/sbom/lib/sbom/cmd/deps_parser.py
+++ b/sbom/lib/sbom/cmd/deps_parser.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
-from pathlib import Path
 import re
 import sbom.errors as sbom_errors
+from sbom.path_utils import PathStr
 
 CONFIG_PATTERN = re.compile(r"\$\(wildcard (include/config/[^)]+)\)")
 WILDCARD_PATTERN = re.compile(r"\$\(wildcard (?P<path>[^)]+)\)")
 VALID_PATH_PATTERN = re.compile(r"^(\/)?(([\w\-\., ]*)\/)*[\w\-\., ]+$")
 
 
-def parse_deps(deps: list[str]) -> list[Path]:
+def parse_deps(deps: list[str]) -> list[PathStr]:
     """
     Parse dependency strings of a .cmd file and return valid input file paths.
     Args:
@@ -18,7 +18,7 @@ def parse_deps(deps: list[str]) -> list[Path]:
     Returns:
         input_files: List of input file paths
     """
-    input_files: list[Path] = []
+    input_files: list[PathStr] = []
     for dep in deps:
         dep = dep.strip()
         match dep:
@@ -26,10 +26,10 @@ def parse_deps(deps: list[str]) -> list[Path]:
                 # config paths like include/config/<CONFIG_NAME> are not included in the graph
                 continue
             case _ if match := WILDCARD_PATTERN.match(dep):
-                path = Path(match.group("path"))
+                path = match.group("path")
                 input_files.append(path)
             case _ if VALID_PATH_PATTERN.match(dep):
-                input_files.append(Path(dep))
+                input_files.append(dep)
 
             case _:
                 sbom_errors.log(f"Skip parsing dependency {dep} because of unrecognized format")

--- a/sbom/lib/sbom/cmd/incbin_parser.py
+++ b/sbom/lib/sbom/cmd/incbin_parser.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
-from pathlib import Path
 import re
+
+from sbom.path_utils import PathStr
 
 INCBIN_PATTERN = re.compile(r'\s*\.incbin\s+"(?P<filename>[^"]+)"')
 """Regex that matches: .incbin "file" statements"""
 
 
-def parse_incbin(path: Path) -> list[Path]:
+def parse_incbin(path: PathStr) -> list[PathStr]:
     """
     File dependencies via .incbin statements in .S assembly files are not covered by the .cmd file dependency mechanism.
 
@@ -20,4 +21,4 @@ def parse_incbin(path: Path) -> list[Path]:
     """
     with open(path, "rt") as f:
         content = f.read()
-    return [Path(match.group("filename")) for match in INCBIN_PATTERN.finditer(content)]
+    return [match.group("filename") for match in INCBIN_PATTERN.finditer(content)]

--- a/sbom/lib/sbom/path_utils.py
+++ b/sbom/lib/sbom/path_utils.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
+
+import os
+
+PathStr = str
+"""Filesystem path represented as a plain string for better performance than pathlib.Path."""
+
+
+def is_relative_to(path: PathStr, base: PathStr) -> bool:
+    return os.path.commonpath([path, base]) == base

--- a/sbom/lib/sbom/spdx/serialization.py
+++ b/sbom/lib/sbom/spdx/serialization.py
@@ -4,8 +4,8 @@
 
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
+from sbom.path_utils import PathStr
 from sbom.spdx.core import SPDX_SPEC_VERSION, SpdxObject
 
 
@@ -20,7 +20,7 @@ class JsonLdDocument:
             "@graph": [item.to_dict() for item in self.graph],
         }
 
-    def save(self, path: Path, prettify: bool) -> None:
+    def save(self, path: PathStr, prettify: bool) -> None:
         with open(path, "w", encoding="utf-8") as f:
             if prettify:
                 json.dump(self.to_dict(), f, indent=2)

--- a/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
+++ b/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
-from pathlib import Path
 import unittest
 
 from sbom.cmd.savedcmd_parser import parse_commands
@@ -12,7 +11,7 @@ class TestSavedCmdParser(unittest.TestCase):
     def _assert_parsing(self, cmd: str, expected: str) -> None:
         sbom_errors.clear()
         parsed = parse_commands(cmd)
-        target = [] if expected == "" else [Path(p) for p in expected.split(" ")]
+        target = [] if expected == "" else expected.split(" ")
         self.assertEqual(parsed, target)
         errors = sbom_errors.get()
         self.assertEqual(errors, [])

--- a/sbom_analysis/module_roots.py
+++ b/sbom_analysis/module_roots.py
@@ -2,35 +2,36 @@
 # SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
 
 import os
-from pathlib import Path
 import re
 import sys
 
 
-def get_module_roots(modules_path: Path) -> list[Path]:
+def get_module_roots(modules_path: str) -> list[str]:
     """
     Parse a modules.order style file and return normalized '.ko' module paths.
 
     Args:
-        modules_path (Path): Path to a file listing module object files (.o) or module kernel object files (.ko) directly.
+        modules_path (str): Path to a file listing module object files (.o) or module kernel object files (.ko) directly.
 
     Returns:
-        module_roots (list[Path]): Normalized paths to corresponding '.ko' modules.
+        module_roots (list[str]): Normalized paths to corresponding '.ko' modules.
     """
     with open(modules_path, "r") as f:
-        modules = [Path(module.strip()) for module in f.readlines()]
-    return [Path(os.path.normpath(module.parent / re.sub(r"\.o$", ".ko", module.name))) for module in modules]
+        modules = [module.strip() for module in f.readlines()]
+    return [os.path.normpath(re.sub(r"\.o$", ".ko", module)) for module in modules]
 
 
 if __name__ == "__main__":
     """
     module_roots.py <modules_path> <output_path>
     """
-    script_path = Path(__file__).parent
+    script_path = os.path.dirname(__file__)
     modules_path = (
-        Path(sys.argv[1]) if sys.argv[1] else (script_path / "../../../linux/kernel_build/modules.order").resolve()
+        sys.argv[1]
+        if sys.argv[1]
+        else os.path.normpath(os.path.join(script_path, "../../../linux/kernel_build/modules.order"))
     )
-    output_path = sys.argv[2] if sys.argv[2] else Path.cwd() / "module_roots.txt"
+    output_path = sys.argv[2] if sys.argv[2] else os.path.join(os.getcwd(), "module_roots.txt")
 
     module_roots = get_module_roots(modules_path)
     with open(output_path, "wt") as f:

--- a/sbom_analysis/profiling/profiler.py
+++ b/sbom_analysis/profiling/profiler.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: 2025 TNG Technology Consulting GmbH
+
+import cProfile
+import os
+import pstats
+import sys
+
+LIB_DIR = "../../sbom/lib"
+SRC_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.join(SRC_DIR, LIB_DIR))
+
+from sbom.cmd.cmd_graph import build_cmd_graph  # noqa: E402
+
+
+root_paths = ["arch/x86/boot/bzImage"]
+src_tree = "../linux"
+output_tree = "../linux/kernel_build"
+os.environ["SRCARCH"] = "x86"
+
+profiler = cProfile.Profile()
+profiler.enable()
+
+# Actual function call
+cmd_graph = build_cmd_graph(root_paths, output_tree, src_tree)
+
+profiler.disable()
+
+# Print stats
+stats = pstats.Stats(profiler)
+stats.sort_stats("cumulative").print_stats(20)


### PR DESCRIPTION
This PR replaces the usage of pathlib.Path objects with plain strings for performance improvements. 
Creating the cmd graph on the tinyconfig using Path objects takes ~13 seconds:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   13.452   13.452 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:32(build_cmd_graph)
        1    0.000    0.000   13.452   13.452 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:34(<listcomp>)
 237524/1    0.568    0.000   13.452   13.452 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:41(build_cmd_graph_node)
      920    0.286    0.000    7.719    0.008 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:102(_parse_cmd_file)
  1202765    0.831    0.000    5.211    0.000 /usr/lib/python3.10/pathlib.py:569(_parse_args)
  1202765    2.775    0.000    4.120    0.000 /usr/lib/python3.10/pathlib.py:56(parse_parts)
   714104    0.275    0.000    3.835    0.000 /usr/lib/python3.10/pathlib.py:957(__new__)
   714104    0.326    0.000    3.560    0.000 /usr/lib/python3.10/pathlib.py:589(_from_parts)
   480113    0.119    0.000    2.744    0.000 /usr/lib/python3.10/pathlib.py:853(__truediv__)
   480113    0.328    0.000    2.626    0.000 /usr/lib/python3.10/pathlib.py:615(_make_child)
   475043    1.004    0.000    2.103    0.000 /usr/lib/python3.10/posixpath.py:338(normpath)
      505    0.276    0.001    1.776    0.004 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/deps_parser.py:13(parse_deps)
  921/920    0.004    0.000    1.166    0.001 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/savedcmd_parser.py:562(parse_commands)
  1429834    0.231    0.000    0.897    0.000 {built-in method posix.fspath}
   965277    0.454    0.000    0.704    0.000 /usr/lib/python3.10/pathlib.py:621(__str__)
   721113    0.151    0.000    0.678    0.000 /usr/lib/python3.10/pathlib.py:631(__fspath__)
      919    0.008    0.000    0.674    0.001 /usr/lib/python3.10/shlex.py:305(split)
    51916    0.010    0.000    0.661    0.000 /usr/lib/python3.10/shlex.py:299(__next__)
      504    0.002    0.000    0.660    0.001 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/savedcmd_parser.py:200(_parse_gcc_or_clang_command)
    51916    0.015    0.000    0.652    0.000 /usr/lib/python3.10/shlex.py:101(get_token)
```
A lot of time is spent in the pathlib library simply converting between str and Path objects and performing simple path operations. 

With the changes in this PR the total runtime gets more than halved to <5 seconds while the generated `sbom.spdx.json` remains the same:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    4.726    4.726 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:32(build_cmd_graph)
        1    0.000    0.000    4.726    4.726 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:34(<listcomp>)
 237524/1    0.267    0.000    4.726    4.726 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:41(build_cmd_graph_node)
      920    0.160    0.000    2.932    0.003 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_graph.py:102(_parse_cmd_file)
   475043    0.881    0.000    1.258    0.000 /usr/lib/python3.10/posixpath.py:338(normpath)
  921/920    0.004    0.000    1.198    0.001 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/savedcmd_parser.py:562(parse_commands)
      919    0.010    0.000    0.687    0.001 /usr/lib/python3.10/shlex.py:305(split)
      504    0.003    0.000    0.677    0.001 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/savedcmd_parser.py:200(_parse_gcc_or_clang_command)
    51916    0.013    0.000    0.673    0.000 /usr/lib/python3.10/shlex.py:299(__next__)
    51916    0.016    0.000    0.660    0.000 /usr/lib/python3.10/shlex.py:101(get_token)
    51916    0.540    0.000    0.644    0.000 /usr/lib/python3.10/shlex.py:133(read_token)
   476313    0.360    0.000    0.577    0.000 /usr/lib/python3.10/posixpath.py:71(join)
      923    0.003    0.000    0.473    0.001 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/savedcmd_parser.py:533(_split_commands)
     1324    0.402    0.000    0.469    0.000 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/savedcmd_parser.py:493(_find_first_top_level_command_separator)
      505    0.176    0.000    0.452    0.001 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/deps_parser.py:13(parse_deps)
      920    0.162    0.000    0.447    0.000 /home/luis/code/WSKernelSbom/KernelSbom/sbom_analysis/profiling/../../sbom/lib/sbom/cmd/cmd_file_parser.py:22(parse_cmd_file)
   975073    0.250    0.000    0.250    0.000 {method 'match' of 're.Pattern' objects}
  4149642    0.204    0.000    0.204    0.000 {method 'append' of 'list' objects}
   237516    0.093    0.000    0.177    0.000 /usr/lib/python3.10/posixpath.py:60(isabs)
   717736    0.102    0.000    0.152    0.000 /usr/lib/python3.10/posixpath.py:41(_get_sep)
```

[Successful Testrun](https://github.com/TNG/KernelSbom/actions/runs/19263358814)

