### PR TITLE
Error Handling Cli Arguments

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -94,6 +94,7 @@ jobs:
             --generate-used-files \
             --package-license "GPL-2.0 WITH Linux-syscall-note" \
             --prettify-json \
+            --write-output-on-error \
             --debug
           
           test_archive="${{ inputs.test_archive }}"

--- a/sbom/lib/sbom/cmd_graph/deps_parser.py
+++ b/sbom/lib/sbom/cmd_graph/deps_parser.py
@@ -11,7 +11,7 @@ WILDCARD_PATTERN = re.compile(r"\$\(wildcard (?P<path>[^)]+)\)")
 VALID_PATH_PATTERN = re.compile(r"^(\/)?(([\w\-\., ]*)\/)*[\w\-\., ]+$")
 
 
-def parse_deps(deps: list[str]) -> list[PathStr]:
+def parse_cmd_file_deps(deps: list[str]) -> list[PathStr]:
     """
     Parse dependency strings of a .cmd file and return valid input file paths.
     Args:

--- a/sbom/lib/sbom/sbom_logging.py
+++ b/sbom/lib/sbom/sbom_logging.py
@@ -3,7 +3,6 @@
 
 import logging
 import inspect
-import sys
 from typing import Any, Literal
 
 
@@ -12,37 +11,41 @@ class MessageLogger:
     and keeps track of repeated messages for a final summary."""
 
     messages: dict[str, list[str]]
+    repeated_logs_limit: int
+    """Maximum number of repeated messages of the same type to log before suppressing further output."""
 
-    def __init__(self, level: Literal["error", "warning"]) -> None:
+    def __init__(self, level: Literal["error", "warning"], repeated_logs_limit: int = 3) -> None:
         self._level = level
         self.messages = {}
+        self.repeated_logs_limit = repeated_logs_limit
 
     def log(self, template: str, /, **kwargs: Any) -> None:
         """Log a message based on a template and optional variables."""
         message = template.format(**kwargs)
         if template not in self.messages:
-            self._emit(message)
             self.messages[template] = []
+        if len(self.messages[template]) < self.repeated_logs_limit:
+            if self._level == "error":
+                logging.error(message)
+            elif self._level == "warning":
+                logging.warning(message)
         self.messages[template].append(message)
 
-    def flush_summary(self, summary_threshold: int = 3) -> None:
-        """Print summary of collected messages."""
+    def get_summary(self) -> str:
+        """Return summary of collected messages."""
+        if len(self.messages) == 0:
+            return ""
+        summary: list[str] = [f"Summarize {self._level}s:"]
         for msgs in self.messages.values():
             for i, msg in enumerate(msgs):
-                if i < summary_threshold:
-                    self._emit(msg)
+                if i < self.repeated_logs_limit:
+                    summary.append(msg)
                     continue
-                self._emit(
+                summary.append(
                     f"... (Found {len(msgs) - i} more {'instances' if (len(msgs) - i) != 1 else 'instance'} of this {self._level})"
                 )
                 break
-
-    def _emit(self, message: str) -> None:
-        """Emit the message at the appropriate logging level."""
-        if self._level == "error":
-            logging.error(message)
-        elif self._level == "warning":
-            logging.warning(message)
+        return "\n".join(summary)
 
 
 _warning_logger: MessageLogger
@@ -64,24 +67,16 @@ def error(msg_template: str, /, **kwargs: Any) -> None:
     _error_logger.log(msg_template, **kwargs)
 
 
-def summarize_errors() -> None:
-    """Flush a summary of collected errors. If errors were found exit 1"""
-    if len(_error_logger.messages) == 0:
-        return
-    logging.error(
-        f"Sbom generation failed with {len(_error_logger.messages)} "
-        f"{'errors' if len(_error_logger.messages) != 1 else 'error'}:"
-    )
-    _error_logger.flush_summary()
-    sys.exit(1)
+def summarize_warnings() -> str:
+    return _warning_logger.get_summary()
 
 
-def summarize_warnings() -> None:
-    """Flush a summary of collected warnings."""
-    if len(_warning_logger.messages) == 0:
-        return
-    logging.warning("Summarize warnings:")
-    _warning_logger.flush_summary()
+def summarize_errors() -> str:
+    return _error_logger.get_summary()
+
+
+def has_errors() -> bool:
+    return len(_error_logger.messages) > 0
 
 
 def init() -> None:

--- a/sbom/lib/sbom/spdx/core.py
+++ b/sbom/lib/sbom/spdx/core.py
@@ -123,6 +123,7 @@ class CreationInfo(SpdxObject):
     specVersion: str = SPDX_SPEC_VERSION
     createdBy: list[Agent]
     created: str = field(default_factory=lambda: datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    comment: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {("@id" if k == "id" else k): v for k, v in super().to_dict().items()}

--- a/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
+++ b/sbom/lib/sbom_tests/cmd/test_savedcmd_parser.py
@@ -3,14 +3,14 @@
 
 import unittest
 
-from sbom.cmd_graph.savedcmd_parser import parse_commands
+from sbom.cmd_graph.savedcmd_parser import parse_inputs_from_commands
 import sbom.sbom_logging as sbom_logging
 
 
 class TestSavedCmdParser(unittest.TestCase):
     def _assert_parsing(self, cmd: str, expected: str) -> None:
         sbom_logging.init()
-        parsed = parse_commands(cmd)
+        parsed = parse_inputs_from_commands(cmd, fail_on_unknown_build_command=False)
         target = [] if expected == "" else expected.split(" ")
         self.assertEqual(parsed, target)
         errors = sbom_logging._error_logger.messages  # type: ignore


### PR DESCRIPTION
This PR introduces two new CLI arguments:
- `--do-not-fail-on-unknown-build-command`
When enabled, the script no longer fails if an unknown build command is encountered while generating the cmd graph. Instead of raising an error, the message is logged as a warning.
- `--write-output-on-error`
Allows the script to write output documents even if an error occurs. The generated SPDX documents may be incomplete.

In addition, this PR adds a summary of warnings and errors to the comment field of the CreationInfo element in all generated SPDX documents. The summary includes up to three messages of the same type. Additional repeated messages are suppressed.

Any individual warning messages, the warning summary, individual error messages, and the error summary are always logged to the console.