### PR TITLE
Support Dynamic Command Parser Patterns

### DIFF
--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -3,9 +3,10 @@
 
 import re
 import shlex
-from typing import Callable
+from typing import Callable, Iterator
 
 import sbom.sbom_logging as sbom_logging
+from sbom.environment import Environment
 from sbom.cmd_graph.savedcmd_parser.command_splitter import IfBlock, split_commands
 from sbom.cmd_graph.savedcmd_parser.tokenizer import (
     CmdParsingError,
@@ -14,6 +15,9 @@ from sbom.cmd_graph.savedcmd_parser.tokenizer import (
     tokenize_single_command_positionals_only,
 )
 from sbom.path_utils import PathStr
+
+CommandParser = Callable[[str], list[PathStr]]
+CommandParserRegistryEntry = tuple[re.Pattern[str], CommandParser]
 
 
 def _parse_dd_command(command: str) -> list[PathStr]:
@@ -30,7 +34,7 @@ def _parse_cat_command(command: str) -> list[PathStr]:
 
 
 def _parse_compound_command(command: str) -> list[PathStr]:
-    compound_command_parsers: list[tuple[re.Pattern[str], Callable[[str], list[PathStr]]]] = [
+    compound_command_parsers: list[CommandParserRegistryEntry] = [
         (re.compile(r"dd\b"), _parse_dd_command),
         (re.compile(r"cat.*?\|"), lambda c: _parse_cat_command(c.split("|")[0])),
         (re.compile(r"cat\b[^|>]*$"), _parse_cat_command),
@@ -357,66 +361,86 @@ def _parse_gen_header(command: str) -> list[PathStr]:
     return [command_parts[i + 1]]
 
 
-# Command parser registry
-SINGLE_COMMAND_PARSERS: list[tuple[re.Pattern[str], Callable[[str], list[PathStr]]]] = [
-    # Compound commands
-    (re.compile(r"\(.*?\)\s*>", re.DOTALL), _parse_compound_command),
-    (re.compile(r"\{.*?\}\s*>", re.DOTALL), _parse_compound_command),
-    # Standard Unix utilities and system tools
-    (re.compile(r"^rm\b"), _parse_noop),
-    (re.compile(r"^mkdir\b"), _parse_noop),
-    (re.compile(r"^touch\b"), _parse_noop),
-    (re.compile(r"^cat\b.*?[\|>]"), lambda c: _parse_cat_command(c.split("|")[0].split(">")[0])),
-    (re.compile(r"^echo[^|]*$"), _parse_noop),
-    (re.compile(r"^sed.*?>"), lambda c: _parse_sed_command(c.split(">")[0])),
-    (re.compile(r"^sed\b"), _parse_noop),
-    (re.compile(r"^awk.*?<.*?>"), lambda c: [c.split("<")[1].split(">")[0]]),
-    (re.compile(r"^awk.*?>"), lambda c: _parse_awk(c.split(">")[0])),
-    (re.compile(r"^(/bin/)?true\b"), _parse_noop),
-    (re.compile(r"^(/bin/)?false\b"), _parse_noop),
-    (re.compile(r"^openssl\s+req.*?-new.*?-keyout"), _parse_noop),
-    # Compilers and code generators
-    # (C/LLVM toolchain, Rust, Flex/Bison, Bindgen, Perl, etc.)
-    (re.compile(r"^([^\s]+-)?(gcc|clang)\b"), _parse_gcc_or_clang_command),
-    (re.compile(r"^([^\s]+-)?ld(\.bfd)?\b"), _parse_ld_command),
-    (re.compile(r"^printf\b.*\| xargs ([^\s]+-)?ar\b"), _parse_ar_piped_xargs_command),
-    (re.compile(r"^([^\s]+-)?ar\b"), _parse_ar_command),
-    (re.compile(r"^([^\s]+-)?nm\b.*?\|"), _parse_nm_piped_command),
-    (re.compile(r"^([^\s]+-)?objcopy\b"), _parse_objcopy_command),
-    (re.compile(r"^([^\s]+-)?strip\b"), _parse_strip_command),
-    (re.compile(r".*?rustc\b"), _parse_rustc_command),
-    (re.compile(r".*?rustdoc\b"), _parse_rustdoc_command),
-    (re.compile(r"^flex\b"), _parse_flex_command),
-    (re.compile(r"^bison\b"), _parse_bison_command),
-    (re.compile(r"^bindgen\b"), _parse_bindgen_command),
-    (re.compile(r"^perl\b"), _parse_perl_command),
-    # Kernel-specific build scripts and tools
-    (re.compile(r"^(.*/)?link-vmlinux\.sh\b"), _parse_link_vmlinux_command),
-    (re.compile(r"sh (.*/)?syscallhdr\.sh\b"), _parse_syscallhdr_command),
-    (re.compile(r"sh (.*/)?syscalltbl\.sh\b"), _parse_syscalltbl_command),
-    (re.compile(r"sh (.*/)?mkcapflags\.sh\b"), _parse_mkcapflags_command),
-    (re.compile(r"sh (.*/)?orc_hash\.sh\b"), _parse_orc_hash_command),
-    (re.compile(r"sh (.*/)?xen-hypercalls\.sh\b"), _parse_xen_hypercalls_command),
-    (re.compile(r"sh (.*/)?gen_initramfs\.sh\b"), _parse_gen_initramfs_command),
-    (re.compile(r"sh (.*/)?checkundef\.sh\b"), _parse_noop),
-    (re.compile(r"(.*/)?vdso2c\b"), _parse_vdso2c_command),
-    (re.compile(r"^(.*/)?mkpiggy.*?>"), _parse_mkpiggy_command),
-    (re.compile(r"^(.*/)?relocs\b"), _parse_relocs_command),
-    (re.compile(r"^(.*/)?mk_elfconfig.*?<.*?>"), _parse_mk_elfconfig_command),
-    (re.compile(r"^(.*/)?tools/build\b"), _parse_tools_build_command),
-    (re.compile(r"^(.*/)?certs/extract-cert"), _parse_extract_cert_command),
-    (re.compile(r"^(.*/)?scripts/dtc/dtc\b"), _parse_dtc_command),
-    (re.compile(r"^(.*/)?pnmtologo\b"), _parse_pnm_to_logo_command),
-    (re.compile(r"^(.*/)?kernel/pi/relacheck"), _parse_relacheck),
-    (re.compile(r"^(.*/)?gen-hyprel\b"), _parse_gen_hyprel_command),
-    (re.compile(r"^drivers/gpu/drm/radeon/mkregtable"), lambda c: [c.split(" ")[1]]),
-    (re.compile(r"(.*/)?genheaders\b"), _parse_noop),
-    (re.compile(r"^(.*/)?mkcpustr\s+>"), _parse_noop),
-    (re.compile(r"^(.*/)polgen\b"), _parse_noop),
-    (re.compile(r"make -f .*/arch/x86/Makefile\.postlink"), _parse_noop),
-    (re.compile(r"^(.*/)?raid6/mktables\s+>"), _parse_noop),
-    (re.compile(r"^(.*/)?objtool\b"), _parse_noop),
-    (re.compile(r"^(.*/)?module/gen_test_kallsyms.sh"), _parse_noop),
-    (re.compile(r"^(.*/)?gen_header.py"), _parse_gen_header),
-    (re.compile(r"^(.*/)?scripts/rustdoc_test_gen"), _parse_noop),
-]
+class CommandParserRegistry:
+    """
+    Registry mapping command patterns to their input-file parsers.
+    """
+
+    def __init__(self, entries: list[CommandParserRegistryEntry]) -> None:
+        self._entries = entries
+
+    def __iter__(self) -> Iterator[CommandParserRegistryEntry]:
+        return iter(self._entries)
+
+    @staticmethod
+    def create() -> "CommandParserRegistry":
+        cc_pattern = Environment.CC() or r"([^\s]+-)?(gcc|clang)"
+        ld_pattern = Environment.LD() or r"([^\s]+-)?ld"
+        ar_pattern = Environment.AR() or r"([^\s]+-)?ar"
+        nm_pattern = Environment.NM() or r"([^\s]+-)?nm"
+        objcopy_pattern = Environment.OBJCOPY() or r"([^\s]+-)?objcopy"
+        strip_pattern = Environment.STRIP() or r"([^\s]+-)?strip"
+
+        entries: list[CommandParserRegistryEntry] = [
+            # Compound commands
+            (re.compile(r"\(.*?\)\s*>", re.DOTALL), _parse_compound_command),
+            (re.compile(r"\{.*?\}\s*>", re.DOTALL), _parse_compound_command),
+            # Standard Unix utilities and system tools
+            (re.compile(r"^rm\b"), _parse_noop),
+            (re.compile(r"^mkdir\b"), _parse_noop),
+            (re.compile(r"^touch\b"), _parse_noop),
+            (re.compile(r"^cat\b.*?[\|>]"), lambda c: _parse_cat_command(c.split("|")[0].split(">")[0])),
+            (re.compile(r"^echo[^|]*$"), _parse_noop),
+            (re.compile(r"^sed.*?>"), lambda c: _parse_sed_command(c.split(">")[0])),
+            (re.compile(r"^sed\b"), _parse_noop),
+            (re.compile(r"^awk.*?<.*?>"), lambda c: [c.split("<")[1].split(">")[0]]),
+            (re.compile(r"^awk.*?>"), lambda c: _parse_awk(c.split(">")[0])),
+            (re.compile(r"^(/bin/)?true\b"), _parse_noop),
+            (re.compile(r"^(/bin/)?false\b"), _parse_noop),
+            (re.compile(r"^openssl\s+req.*?-new.*?-keyout"), _parse_noop),
+            # Compilers and code generators
+            # (C/LLVM toolchain, Rust, Flex/Bison, Bindgen, Perl, etc.)
+            (re.compile(rf"^{cc_pattern}\b"), _parse_gcc_or_clang_command),
+            (re.compile(rf"^{ld_pattern}\b"), _parse_ld_command),
+            (re.compile(rf"^printf\b.*\| xargs {ar_pattern}\b"), _parse_ar_piped_xargs_command),
+            (re.compile(rf"^{ar_pattern}\b"), _parse_ar_command),
+            (re.compile(rf"^{nm_pattern}\b.*?\|"), _parse_nm_piped_command),
+            (re.compile(rf"^{objcopy_pattern}\b"), _parse_objcopy_command),
+            (re.compile(rf"^{strip_pattern}\b"), _parse_strip_command),
+            (re.compile(r".*?rustc\b"), _parse_rustc_command),
+            (re.compile(r".*?rustdoc\b"), _parse_rustdoc_command),
+            (re.compile(r"^flex\b"), _parse_flex_command),
+            (re.compile(r"^bison\b"), _parse_bison_command),
+            (re.compile(r"^bindgen\b"), _parse_bindgen_command),
+            (re.compile(r"^perl\b"), _parse_perl_command),
+            # Kernel-specific build scripts and tools
+            (re.compile(r"^(.*/)?link-vmlinux\.sh\b"), _parse_link_vmlinux_command),
+            (re.compile(r"sh (.*/)?syscallhdr\.sh\b"), _parse_syscallhdr_command),
+            (re.compile(r"sh (.*/)?syscalltbl\.sh\b"), _parse_syscalltbl_command),
+            (re.compile(r"sh (.*/)?mkcapflags\.sh\b"), _parse_mkcapflags_command),
+            (re.compile(r"sh (.*/)?orc_hash\.sh\b"), _parse_orc_hash_command),
+            (re.compile(r"sh (.*/)?xen-hypercalls\.sh\b"), _parse_xen_hypercalls_command),
+            (re.compile(r"sh (.*/)?gen_initramfs\.sh\b"), _parse_gen_initramfs_command),
+            (re.compile(r"sh (.*/)?checkundef\.sh\b"), _parse_noop),
+            (re.compile(r"(.*/)?vdso2c\b"), _parse_vdso2c_command),
+            (re.compile(r"^(.*/)?mkpiggy.*?>"), _parse_mkpiggy_command),
+            (re.compile(r"^(.*/)?relocs\b"), _parse_relocs_command),
+            (re.compile(r"^(.*/)?mk_elfconfig.*?<.*?>"), _parse_mk_elfconfig_command),
+            (re.compile(r"^(.*/)?tools/build\b"), _parse_tools_build_command),
+            (re.compile(r"^(.*/)?certs/extract-cert"), _parse_extract_cert_command),
+            (re.compile(r"^(.*/)?scripts/dtc/dtc\b"), _parse_dtc_command),
+            (re.compile(r"^(.*/)?pnmtologo\b"), _parse_pnm_to_logo_command),
+            (re.compile(r"^(.*/)?kernel/pi/relacheck"), _parse_relacheck),
+            (re.compile(r"^(.*/)?gen-hyprel\b"), _parse_gen_hyprel_command),
+            (re.compile(r"^drivers/gpu/drm/radeon/mkregtable"), lambda c: [c.split(" ")[1]]),
+            (re.compile(r"(.*/)?genheaders\b"), _parse_noop),
+            (re.compile(r"^(.*/)?mkcpustr\s+>"), _parse_noop),
+            (re.compile(r"^(.*/)polgen\b"), _parse_noop),
+            (re.compile(r"make -f .*/arch/x86/Makefile\.postlink"), _parse_noop),
+            (re.compile(r"^(.*/)?raid6/mktables\s+>"), _parse_noop),
+            (re.compile(r"^(.*/)?objtool\b"), _parse_noop),
+            (re.compile(r"^(.*/)?module/gen_test_kallsyms.sh"), _parse_noop),
+            (re.compile(r"^(.*/)?gen_header.py"), _parse_gen_header),
+            (re.compile(r"^(.*/)?scripts/rustdoc_test_gen"), _parse_noop),
+        ]
+        return CommandParserRegistry(entries)

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -128,9 +128,9 @@ def _parse_ar_piped_xargs_command(command: str) -> list[PathStr]:
 
 def _parse_gcc_or_clang_command(command: str) -> list[PathStr]:
     parts = shlex.split(command)
-    # compile mode: expect last positional argument ending in `.c` or `.S` to be the input file
+    # compile mode: expect last positional argument ending in a source file extension to be the input file
     for part in reversed(parts):
-        if not part.startswith("-") and any(part.endswith(suffix) for suffix in [".c", ".S"]):
+        if not part.startswith("-") and any(part.endswith(suffix) for suffix in [".c", ".S", ".dts"]):
             return [part]
 
     # linking mode: expect all .o files to be the inputs

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -374,12 +374,17 @@ class CommandParserRegistry:
 
     @staticmethod
     def create() -> "CommandParserRegistry":
-        cc_pattern = Environment.CC() or r"([^\s]+-)?(gcc|clang)"
-        ld_pattern = Environment.LD() or r"([^\s]+-)?ld"
-        ar_pattern = Environment.AR() or r"([^\s]+-)?ar"
-        nm_pattern = Environment.NM() or r"([^\s]+-)?nm"
-        objcopy_pattern = Environment.OBJCOPY() or r"([^\s]+-)?objcopy"
-        strip_pattern = Environment.STRIP() or r"([^\s]+-)?strip"
+        def env_or_default_pattern(env_value: str | None, default_pattern: str) -> str:
+            if env_value is None or not env_value.strip():
+                return default_pattern
+            return rf"(?:{re.escape(env_value.strip())}|{default_pattern})"
+
+        cc_pattern = env_or_default_pattern(Environment.CC(), r"([^\s]+-)?(gcc|clang)")
+        ld_pattern = env_or_default_pattern(Environment.LD(), r"([^\s]+-)?ld")
+        ar_pattern = env_or_default_pattern(Environment.AR(), r"([^\s]+-)?ar")
+        nm_pattern = env_or_default_pattern(Environment.NM(), r"([^\s]+-)?nm")
+        objcopy_pattern = env_or_default_pattern(Environment.OBJCOPY(), r"([^\s]+-)?objcopy")
+        strip_pattern = env_or_default_pattern(Environment.STRIP(), r"([^\s]+-)?strip")
 
         entries: list[CommandParserRegistryEntry] = [
             # Compound commands
@@ -400,13 +405,36 @@ class CommandParserRegistry:
             (re.compile(r"^openssl\s+req.*?-new.*?-keyout"), _parse_noop),
             # Compilers and code generators
             # (C/LLVM toolchain, Rust, Flex/Bison, Bindgen, Perl, etc.)
-            (re.compile(rf"^{cc_pattern}\b"), _parse_gcc_or_clang_command),
-            (re.compile(rf"^{ld_pattern}\b"), _parse_ld_command),
-            (re.compile(rf"^printf\b.*\| xargs {ar_pattern}\b"), _parse_ar_piped_xargs_command),
-            (re.compile(rf"^{ar_pattern}\b"), _parse_ar_command),
-            (re.compile(rf"^{nm_pattern}\b.*?\|"), _parse_nm_piped_command),
-            (re.compile(rf"^{objcopy_pattern}\b"), _parse_objcopy_command),
-            (re.compile(rf"^{strip_pattern}\b"), _parse_strip_command),
+            (
+                re.compile(rf"^{cc_pattern}\b"),
+                lambda command: _parse_gcc_or_clang_command(re.sub(rf"^{cc_pattern}\b", "gcc", command, count=1)),
+            ),
+            (
+                re.compile(rf"^{ld_pattern}\b"),
+                lambda command: _parse_ld_command(re.sub(rf"^{ld_pattern}\b", "ld", command, count=1)),
+            ),
+            (
+                re.compile(rf"^printf\b.*\| xargs {ar_pattern}\b"),
+                lambda command: _parse_ar_piped_xargs_command(
+                    re.sub(rf"xargs {ar_pattern}\b", "xargs ar", command, count=1)
+                ),
+            ),
+            (
+                re.compile(rf"^{ar_pattern}\b"),
+                lambda command: _parse_ar_command(re.sub(rf"^{ar_pattern}\b", "ar", command, count=1)),
+            ),
+            (
+                re.compile(rf"^{nm_pattern}\b.*?\|"),
+                lambda command: _parse_nm_piped_command(re.sub(rf"^{nm_pattern}\b", "nm", command, count=1)),
+            ),
+            (
+                re.compile(rf"^{objcopy_pattern}\b"),
+                lambda command: _parse_objcopy_command(re.sub(rf"^{objcopy_pattern}\b", "objcopy", command, count=1)),
+            ),
+            (
+                re.compile(rf"^{strip_pattern}\b"),
+                lambda command: _parse_strip_command(re.sub(rf"^{strip_pattern}\b", "strip", command, count=1)),
+            ),
             (re.compile(r".*?rustc\b"), _parse_rustc_command),
             (re.compile(r".*?rustdoc\b"), _parse_rustdoc_command),
             (re.compile(r"^flex\b"), _parse_flex_command),

--- a/sbom/sbom/cmd_graph/savedcmd_parser/savedcmd_parser.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/savedcmd_parser.py
@@ -4,18 +4,25 @@
 from typing import Any
 import sbom.sbom_logging as sbom_logging
 from sbom.cmd_graph.savedcmd_parser.command_splitter import IfBlock, split_commands
-from sbom.cmd_graph.savedcmd_parser.single_command_parsers import SINGLE_COMMAND_PARSERS
+from sbom.cmd_graph.savedcmd_parser.command_parser_registry import CommandParserRegistry
 from sbom.cmd_graph.savedcmd_parser.tokenizer import CmdParsingError
 from sbom.path_utils import PathStr
 
+DEFAULT_COMMAND_PARSER_REGISTRY = CommandParserRegistry.create()
 
-def parse_inputs_from_commands(commands: str, fail_on_unknown_build_command: bool) -> list[PathStr]:
+
+def parse_inputs_from_commands(
+    commands: str,
+    fail_on_unknown_build_command: bool,
+    registry: CommandParserRegistry | None = None,
+) -> list[PathStr]:
     """
     Extract input files referenced in a set of command-line commands.
 
     Args:
         commands (str): Command line expression to parse.
         fail_on_unknown_build_command (bool): Whether to fail if an unknown build command is encountered. If False, errors are logged as warnings.
+        registry (CommandParserRegistry | None): Registry of single command parsers.
 
     Returns:
         list[PathStr]: List of input file paths required by the commands.
@@ -27,10 +34,13 @@ def parse_inputs_from_commands(commands: str, fail_on_unknown_build_command: boo
         else:
             sbom_logging.warning(message, **kwargs)
 
+    if registry is None:
+        registry = DEFAULT_COMMAND_PARSER_REGISTRY
+
     input_files: list[PathStr] = []
     for single_command in split_commands(commands):
         if isinstance(single_command, IfBlock):
-            inputs = parse_inputs_from_commands(single_command.then_statement, fail_on_unknown_build_command)
+            inputs = parse_inputs_from_commands(single_command.then_statement, fail_on_unknown_build_command, registry)
             if inputs:
                 log_error_or_warning(
                     "Skipped parsing command {then_statement} because input files in IfBlock 'then' statement are not supported",
@@ -38,9 +48,7 @@ def parse_inputs_from_commands(commands: str, fail_on_unknown_build_command: boo
                 )
             continue
 
-        matched_parser = next(
-            (parser for pattern, parser in SINGLE_COMMAND_PARSERS if pattern.match(single_command)), None
-        )
+        matched_parser = next((parser for pattern, parser in registry if pattern.match(single_command)), None)
         if matched_parser is None:
             log_error_or_warning(
                 "Skipped parsing command {single_command} because no matching parser was found",

--- a/sbom/sbom/environment.py
+++ b/sbom/sbom/environment.py
@@ -166,3 +166,27 @@ class Environment:
     @classmethod
     def SRCARCH(cls) -> str | None:
         return os.getenv("SRCARCH")
+
+    @classmethod
+    def CC(cls) -> str | None:
+        return os.getenv("CC")
+
+    @classmethod
+    def LD(cls) -> str | None:
+        return os.getenv("LD")
+
+    @classmethod
+    def AR(cls) -> str | None:
+        return os.getenv("AR")
+
+    @classmethod
+    def NM(cls) -> str | None:
+        return os.getenv("NM")
+
+    @classmethod
+    def OBJCOPY(cls) -> str | None:
+        return os.getenv("OBJCOPY")
+
+    @classmethod
+    def STRIP(cls) -> str | None:
+        return os.getenv("STRIP")

--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -241,7 +241,7 @@ def _get_primary_purpose(absolute_path: PathStr) -> SoftwarePurpose | None:
         return any(segment in absolute_path for segment in path_segments)
 
     # Source code
-    if ends_with([".c", ".h", ".S", ".s", ".rs", ".pl"]):
+    if ends_with([".c", ".h", ".S", ".s", ".rs", ".pl", "gen_smb2_mapping"]):
         return "source"
 
     # Libraries

--- a/sbom/tests/cmd_graph/test_savedcmd_parser.py
+++ b/sbom/tests/cmd_graph/test_savedcmd_parser.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only OR MIT
 # Copyright (C) 2025 TNG Technology Consulting GmbH
 
+import os
 import unittest
 
 from sbom.cmd_graph.savedcmd_parser import parse_inputs_from_commands
+from sbom.cmd_graph.savedcmd_parser.command_parser_registry import CommandParserRegistry
 import sbom.sbom_logging as sbom_logging
 
 
 class TestSavedCmdParser(unittest.TestCase):
-    def _assert_parsing(self, cmd: str, expected: str) -> None:
+    def _assert_parsing(self, cmd: str, expected: str, registry: CommandParserRegistry | None = None) -> None:
         sbom_logging.init()
-        parsed = parse_inputs_from_commands(cmd, fail_on_unknown_build_command=False)
+        parsed = parse_inputs_from_commands(cmd, fail_on_unknown_build_command=False, registry=registry)
         target = [] if expected == "" else expected.split(" ")
         self.assertEqual(parsed, target)
         errors = sbom_logging._error_logger.messages  # type: ignore
@@ -109,6 +111,13 @@ class TestSavedCmdParser(unittest.TestCase):
         cmd = "gcc -Wp,-MMD,arch/x86/boot/compressed/.mkpiggy.d -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -std=gnu11   -I ../scripts/include -I../tools/include  -I arch/x86/boot/compressed   -o arch/x86/boot/compressed/mkpiggy ../arch/x86/boot/compressed/mkpiggy.c"
         expected = "../arch/x86/boot/compressed/mkpiggy.c"
         self._assert_parsing(cmd, expected)
+
+    def test_gcc_with_ccache(self):
+        os.environ["CC"] = "ccache gcc"
+        registry = CommandParserRegistry.create()
+        cmd = "ccache gcc   -o arch/x86/tools/relocs arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
+        expected = "arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
+        self._assert_parsing(cmd, expected, registry)
 
     def test_clang(self):
         cmd = """clang -Wp,-MMD,arch/x86/entry/.entry_64_compat.o.d -nostdinc -I../arch/x86/include -I./arch/x86/include/generated -I../include -I./include -I../arch/x86/include/uapi -I./arch/x86/include/generated/uapi -I../include/uapi -I./include/generated/uapi -include ../include/linux/compiler-version.h -include ../include/linux/kconfig.h -D__KERNEL__ --target=x86_64-linux-gnu -fintegrated-as -Werror=unknown-warning-option -Werror=ignored-optimization-argument -Werror=option-ignored -Werror=unused-command-line-argument -fmacro-prefix-map=../= -Werror -D__ASSEMBLY__ -fno-PIE -m64 -I../arch/x86/entry -Iarch/x86/entry    -DKBUILD_MODFILE='"arch/x86/entry/entry_64_compat"' -DKBUILD_MODNAME='"entry_64_compat"' -D__KBUILD_MODNAME=kmod_entry_64_compat -c -o arch/x86/entry/entry_64_compat.o ../arch/x86/entry/entry_64_compat.S"""

--- a/sbom/tests/cmd_graph/test_savedcmd_parser.py
+++ b/sbom/tests/cmd_graph/test_savedcmd_parser.py
@@ -119,6 +119,11 @@ class TestSavedCmdParser(unittest.TestCase):
         expected = "arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
         self._assert_parsing(cmd, expected, registry)
 
+    def test_gcc_dts_preprocessing(self):
+        cmd = "gcc -E -Wp,-MMD,drivers/of/.empty_root.dtb.d.pre.tmp -nostdinc -I ../scripts/dtc/include-prefixes -undef -D__DTS__ -x assembler-with-cpp -o drivers/of/.empty_root.dtb.dts.tmp ../drivers/of/empty_root.dts"
+        expected = "../drivers/of/empty_root.dts"
+        self._assert_parsing(cmd, expected)
+
     def test_clang(self):
         cmd = """clang -Wp,-MMD,arch/x86/entry/.entry_64_compat.o.d -nostdinc -I../arch/x86/include -I./arch/x86/include/generated -I../include -I./include -I../arch/x86/include/uapi -I./arch/x86/include/generated/uapi -I../include/uapi -I./include/generated/uapi -include ../include/linux/compiler-version.h -include ../include/linux/kconfig.h -D__KERNEL__ --target=x86_64-linux-gnu -fintegrated-as -Werror=unknown-warning-option -Werror=ignored-optimization-argument -Werror=option-ignored -Werror=unused-command-line-argument -fmacro-prefix-map=../= -Werror -D__ASSEMBLY__ -fno-PIE -m64 -I../arch/x86/entry -Iarch/x86/entry    -DKBUILD_MODFILE='"arch/x86/entry/entry_64_compat"' -DKBUILD_MODNAME='"entry_64_compat"' -D__KBUILD_MODNAME=kmod_entry_64_compat -c -o arch/x86/entry/entry_64_compat.o ../arch/x86/entry/entry_64_compat.S"""
         expected = "../arch/x86/entry/entry_64_compat.S"

--- a/sbom/tests/cmd_graph/test_savedcmd_parser.py
+++ b/sbom/tests/cmd_graph/test_savedcmd_parser.py
@@ -112,12 +112,13 @@ class TestSavedCmdParser(unittest.TestCase):
         expected = "../arch/x86/boot/compressed/mkpiggy.c"
         self._assert_parsing(cmd, expected)
 
-    def test_gcc_with_ccache(self):
+    def test_gcc_with_env_override(self):
         os.environ["CC"] = "ccache gcc"
         registry = CommandParserRegistry.create()
-        cmd = "ccache gcc   -o arch/x86/tools/relocs arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
+        cmd = "gcc   -o arch/x86/tools/relocs arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
         expected = "arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
         self._assert_parsing(cmd, expected, registry)
+        self._assert_parsing(f"ccache {cmd}", expected, registry)
 
     def test_gcc_dts_preprocessing(self):
         cmd = "gcc -E -Wp,-MMD,drivers/of/.empty_root.dtb.d.pre.tmp -nostdinc -I ../scripts/dtc/include-prefixes -undef -D__DTS__ -x assembler-with-cpp -o drivers/of/.empty_root.dtb.dts.tmp ../drivers/of/empty_root.dts"
@@ -134,6 +135,14 @@ class TestSavedCmdParser(unittest.TestCase):
         cmd = 'ld -o arch/x86/entry/vdso/vdso64.so.dbg -shared --hash-style=both --build-id=sha1 --no-undefined  --eh-frame-hdr -Bsymbolic -z noexecstack -m elf_x86_64 -soname linux-vdso.so.1 -z max-page-size=4096 -T arch/x86/entry/vdso/vdso.lds arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o; if readelf -rW arch/x86/entry/vdso/vdso64.so.dbg | grep -v _NONE | grep -q " R_\w*_"; then (echo >&2 "arch/x86/entry/vdso/vdso64.so.dbg: dynamic relocations are not supported"; rm -f arch/x86/entry/vdso/vdso64.so.dbg; /bin/false); fi'  # type: ignore
         expected = "arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o"
         self._assert_parsing(cmd, expected)
+
+    def test_ld_with_env_override(self):
+        os.environ["LD"] = "some-tool ld"
+        registry = CommandParserRegistry.create()
+        cmd = 'ld -o arch/x86/entry/vdso/vdso64.so.dbg -shared --hash-style=both --build-id=sha1 --no-undefined  --eh-frame-hdr -Bsymbolic -z noexecstack -m elf_x86_64 -soname linux-vdso.so.1 -z max-page-size=4096 -T arch/x86/entry/vdso/vdso.lds arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o; if readelf -rW arch/x86/entry/vdso/vdso64.so.dbg | grep -v _NONE | grep -q " R_\w*_"; then (echo >&2 "arch/x86/entry/vdso/vdso64.so.dbg: dynamic relocations are not supported"; rm -f arch/x86/entry/vdso/vdso64.so.dbg; /bin/false); fi'  # type: ignore
+        expected = "arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o"
+        self._assert_parsing(cmd, expected, registry)
+        self._assert_parsing(f"some-tool {cmd}", expected, registry)
 
     def test_ld_whole_archive(self):
         cmd = "ld -m elf_x86_64 -z noexecstack -r -o vmlinux.o   --whole-archive vmlinux.a --no-whole-archive --start-group  --end-group"


### PR DESCRIPTION
This PR adds support for parsing commands that are overwritten by custom environment variables like 
- `CC`
- `LD`
- `AR`
- `NM`
- `OBJCOPY`
- `STRIP`

which is a common thing to do within the kernel make process. 
For example, via
```bash
make CC="ccache gcc"
```
which overwrites each `gcc` invocation with `ccache gcc` which is stored as such in the `.cmd` files.

[Successful workflow run on all configs](https://github.com/TNG/KernelSbom/actions/runs/23854619557)
