### PR TITLE
Add parsers for arm mkuboot.sh and syscallnr.sh

### DIFF
--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -374,6 +374,21 @@ def _parse_gen_header(command: str) -> list[PathStr]:
         raise CmdParsingError(f"Expected --xml input file in gen_headers command but got {command}")
     return [command_parts[i + 1]]
 
+def _parse_mkuboot_command(command: str) -> list[PathStr]:
+    command_parts = tokenize_single_command(command)
+    # mkuboot.sh passes all args to mkimage; -d specifies the data/input image file
+    for part in command_parts:
+        if isinstance(part, Option) and part.name == "-d" and part.value is not None:
+            return [part.value]
+    raise CmdParsingError("Could not find -d (data file) option in mkuboot.sh command")
+
+
+def _parse_syscallnr_command(command: str) -> list[PathStr]:
+    command_parts = tokenize_single_command(command.strip())
+    positionals = [p.value for p in command_parts if isinstance(p, Positional)]
+    # expect positionals to be ["sh", path/to/syscallnr.sh, input, output]
+    return [positionals[2]]
+
 
 class CommandParserRegistry:
     """
@@ -466,6 +481,8 @@ class CommandParserRegistry:
             (re.compile(r"sh (.*/)?xen-hypercalls\.sh\b"), _parse_xen_hypercalls_command),
             (re.compile(r"sh (.*/)?gen_initramfs\.sh\b"), _parse_gen_initramfs_command),
             (re.compile(r"sh (.*/)?checkundef\.sh\b"), _parse_noop),
+            (re.compile(r"(bash|sh) (.*/)?mkuboot\.sh\b"), _parse_mkuboot_command),
+            (re.compile(r"sh (.*/)?syscallnr\.sh\b"), _parse_syscallnr_command),
             (re.compile(r"(.*/)?vdso2c\b"), _parse_vdso2c_command),
             (re.compile(r"(.*/)?vdsomunge\b"), _parse_vdsomunge_command),
             (re.compile(r"^(.*/)?mkpiggy.*?>"), _parse_mkpiggy_command),

--- a/sbom/tests/cmd_graph/test_savedcmd_parser.py
+++ b/sbom/tests/cmd_graph/test_savedcmd_parser.py
@@ -317,6 +317,18 @@ class TestSavedCmdParser(unittest.TestCase):
         expected = "../usr/default_cpio_list"
         self._assert_parsing(cmd, expected)
 
+    # mkuboot.sh command tests
+    def test_mkuboot(self):
+        cmd = "bash ../scripts/mkuboot.sh -A arm -O linux -C none -T kernel -a 0x8000 -e 0x8000 -n 'Linux-6.15.0' -d arch/arm/boot/zImage arch/arm/boot/uImage"
+        expected = "arch/arm/boot/zImage"
+        self._assert_parsing(cmd, expected)
+
+    # syscallnr.sh command tests
+    def test_syscallnr(self):
+        cmd = "sh ../arch/arm/tools/syscallnr.sh ../arch/arm/tools/syscall.tbl arch/arm/include/generated/asm/unistd-nr.h"
+        expected = "../arch/arm/tools/syscall.tbl"
+        self._assert_parsing(cmd, expected)
+
     # vdso2c command tests
     def test_vdso2c(self):
         cmd = "arch/x86/entry/vdso/vdso2c arch/x86/entry/vdso/vdso64.so.dbg arch/x86/entry/vdso/vdso64.so arch/x86/entry/vdso/vdso-image-64.c"


### PR DESCRIPTION
Add support to targets that depends on those commands:

  bash .../scripts/mkuboot.sh -A arm -O linux ... -d <input> <output>
  sh .../arch/arm/tools/syscallnr.sh <input.tbl> <output.h>

Add _parse_mkuboot_command: mkuboot.sh is a thin wrapper around mkimage(1); the input file is the argument to the -d flag.

Add _parse_syscallnr_command: follows the same positional convention as the existing syscalltbl.sh parser, positionals[2] is the input syscall table file.

Register both in SINGLE_COMMAND_PARSERS alongside the other ARM/sh script entries.

Solves:
```

[ERROR] File ".../site-packages/kernel_sbom/cmd_graph/savedcmd_parser.py", line 630, in log_error_or_warning
Skipped parsing command sh .../linux/arch/arm/tools/syscallnr.sh .../linux/arch/arm/tools/syscall.tbl arch/arm/include/generated/asm/unistd-nr.h because no matching parser was found
```