### PR TITLE
Fix Sashiko Issues

### DIFF
--- a/sbom/sbom.py
+++ b/sbom/sbom.py
@@ -41,7 +41,7 @@ def main():
     if config.generate_used_files:
         if config.src_tree == config.obj_tree:
             logging.info(
-                f"Extracting all files from the cmd graph to {(config.used_files_file_name,)} "
+                f"Extracting all files from the cmd graph to {config.used_files_file_name} "
                 "instead of only source files because source files cannot be "
                 "reliably classified when the source and object trees are identical.",
             )

--- a/sbom/sbom/cmd_graph/cmd_file.py
+++ b/sbom/sbom/cmd_graph/cmd_file.py
@@ -39,7 +39,7 @@ class CmdFile:
 
         3. Single Dependency Cmd File
             (saved)?cmd_<output> := <command>
-            <output> := <dependency>
+            <output> : <dependency>
 
         Args:
             cmd_file_path (Path): absolute Path to a .cmd file
@@ -51,7 +51,7 @@ class CmdFile:
             lines = [line.strip() for line in f.readlines() if line.strip() != "" and not line.startswith("#")]
 
         # savedcmd
-        match = SAVEDCMD_PATTERN.match(lines[0])
+        match = SAVEDCMD_PATTERN.match(lines[0] if lines else "")
         if match is None:
             sbom_logging.error(
                 "Skip parsing '{cmd_file_path}' because no 'savedcmd_' command was found.", cmd_file_path=cmd_file_path
@@ -65,7 +65,13 @@ class CmdFile:
 
         # Single Dependency Cmd File
         if len(lines) == 2:
-            dep = lines[1].split(":")[1].strip()
+            parts = lines[1].split(":", 1)
+            if len(parts) != 2:
+                sbom_logging.error(
+                    "Skip parsing '{cmd_file_path}'. Expected dependency line '<output>: <dependency>' but got {second_line}", cmd_file_path=cmd_file_path, second_line=lines[1]
+                )
+                return None
+            dep = parts[1].strip()
             return CmdFile(cmd_file_path, savedcmd, deps=[dep])
 
         # Full Cmd File
@@ -143,7 +149,14 @@ def _expand_resolve_files(input_files: list[PathStr], obj_tree: PathStr) -> list
         if not input_file.startswith("@"):
             expanded_input_files.append(input_file)
             continue
-        with open(os.path.join(obj_tree, input_file.lstrip("@")), "rt") as f:
+        resolve_file_path = os.path.join(obj_tree, input_file.lstrip("@"))
+        if not os.path.exists(resolve_file_path):
+            sbom_logging.error(
+                "Skip resolving '{resolve_file_path}' because the response file does not exist.",
+                resolve_file_path=resolve_file_path,
+            )
+            continue
+        with open(resolve_file_path, "rt") as f:
             resolve_file_content = [line_stripped for line in f.readlines() if (line_stripped := line.strip())]
         expanded_input_files += _expand_resolve_files(resolve_file_content, obj_tree)
     return expanded_input_files

--- a/sbom/sbom/cmd_graph/cmd_file.py
+++ b/sbom/sbom/cmd_graph/cmd_file.py
@@ -18,8 +18,8 @@ class CmdFile:
     cmd_file_path: PathStr
     savedcmd: str
     source: PathStr | None = None
-    deps: list[str] = field(default_factory=list[str])
-    make_rules: list[str] = field(default_factory=list[str])
+    deps: list[str] = field(default_factory=list)
+    make_rules: list[str] = field(default_factory=list)
 
     @classmethod
     def create(cls, cmd_file_path: PathStr) -> "CmdFile | None":

--- a/sbom/sbom/cmd_graph/cmd_graph.py
+++ b/sbom/sbom/cmd_graph/cmd_graph.py
@@ -13,7 +13,7 @@ from sbom.path_utils import PathStr
 class CmdGraph:
     """Directed acyclic graph of build dependencies primarily inferred from .cmd files produced during kernel builds"""
 
-    roots: list[CmdGraphNode] = field(default_factory=list[CmdGraphNode])
+    roots: list[CmdGraphNode] = field(default_factory=list)
 
     @classmethod
     def create(cls, root_paths: list[PathStr], config: CmdGraphNodeConfig) -> "CmdGraph":

--- a/sbom/sbom/cmd_graph/cmd_graph_node.py
+++ b/sbom/sbom/cmd_graph/cmd_graph_node.py
@@ -36,9 +36,9 @@ class CmdGraphNode:
     cmd_file: CmdFile | None = None
     """Parsed .cmd file describing how the file at absolute_path was built, or None if not available."""
 
-    cmd_file_dependencies: list["CmdGraphNode"] = field(default_factory=list["CmdGraphNode"])
-    incbin_dependencies: list[IncbinDependency] = field(default_factory=list[IncbinDependency])
-    hardcoded_dependencies: list["CmdGraphNode"] = field(default_factory=list["CmdGraphNode"])
+    cmd_file_dependencies: list["CmdGraphNode"] = field(default_factory=list)
+    incbin_dependencies: list[IncbinDependency] = field(default_factory=list)
+    hardcoded_dependencies: list["CmdGraphNode"] = field(default_factory=list)
 
     @property
     def children(self) -> Iterator["CmdGraphNode"]:

--- a/sbom/sbom/cmd_graph/cmd_graph_node.py
+++ b/sbom/sbom/cmd_graph/cmd_graph_node.py
@@ -11,7 +11,7 @@ from sbom import sbom_logging
 from sbom.cmd_graph.cmd_file import CmdFile
 from sbom.cmd_graph.hardcoded_dependencies import get_hardcoded_dependencies
 from sbom.cmd_graph.incbin_parser import parse_incbin_statements
-from sbom.path_utils import PathStr, is_relative_to
+from sbom.path_utils import PathStr, has_link, is_relative_to
 
 
 @dataclass
@@ -78,7 +78,7 @@ class CmdGraphNode:
 
         target_path_absolute = (
             os.path.realpath(p)
-            if os.path.islink(p := os.path.join(config.obj_tree, target_path))
+            if has_link(p:=os.path.join(config.obj_tree, target_path))
             else os.path.normpath(p)
         )
 

--- a/sbom/sbom/cmd_graph/deps_parser.py
+++ b/sbom/sbom/cmd_graph/deps_parser.py
@@ -19,10 +19,10 @@ WILDCARD_PATTERN = re.compile(r"\$\(wildcard (?P<path>[^)]+)\)")
 
 # Match ordinary paths:
 # - ^(\/)?: Optionally starts with a '/'
-# - (([\w\-\., ]*)\/)*: Zero or more directory levels
-# - [\w\-\., ]+$: Path component (file or directory)
+# - (([\w\-\.,+~=@ ]*)\/)*: Zero or more directory levels
+# - [\w\-\.,+~=@ ]+$: Path component (file or directory)
 # Example matches: "/foo/bar.c", "dir1/dir2/file.txt", "plainfile"
-VALID_PATH_PATTERN = re.compile(r"^(\/)?(([\w\-\., ]*)\/)*[\w\-\., ]+$")
+VALID_PATH_PATTERN = re.compile(r"^(\/)?(([\w\-\.,+~=@ ]*)\/)*[\w\-\.,+~=@ ]+$")
 
 
 def parse_cmd_file_deps(deps: list[str]) -> list[PathStr]:

--- a/sbom/sbom/cmd_graph/hardcoded_dependencies.py
+++ b/sbom/sbom/cmd_graph/hardcoded_dependencies.py
@@ -14,7 +14,11 @@ HARDCODED_DEPENDENCIES: dict[str, list[str]] = {
     "include/generated/bounds.h": ["kernel/bounds.s"],
     "include/generated/asm-offsets.h": ["arch/{arch}/kernel/asm-offsets.s"],
 }
-
+"""
+Maps file paths to the list of dependencies required to build them
+which are not tracked by the .cmd dependency mechanism.
+Paths are relative to either the source tree or the object tree.
+"""
 
 def get_hardcoded_dependencies(path: PathStr, obj_tree: PathStr, src_tree: PathStr) -> list[PathStr]:
     """
@@ -49,8 +53,8 @@ def get_hardcoded_dependencies(path: PathStr, obj_tree: PathStr, src_tree: PathS
             continue
         if os.path.exists(os.path.join(obj_tree, dependency)):
             dependencies.append(dependency)
-        elif os.path.exists(os.path.join(src_tree, dependency)):
-            dependencies.append(os.path.relpath(dependency, obj_tree))
+        elif os.path.exists(dependency_absolute := os.path.join(src_tree, dependency)):
+            dependencies.append(os.path.relpath(dependency_absolute, obj_tree))
         else:
             sbom_logging.error(
                 "Skip hardcoded dependency '{dependency}' for '{path}' because the dependency lies neither in the src tree nor the object tree.",

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -10,6 +10,7 @@ from sbom.environment import Environment
 from sbom.cmd_graph.savedcmd_parser.command_splitter import IfBlock, split_commands
 from sbom.cmd_graph.savedcmd_parser.tokenizer import (
     CmdParsingError,
+    Option,
     Positional,
     tokenize_single_command,
     tokenize_single_command_positionals_only,
@@ -231,9 +232,12 @@ def _parse_sed_command(command: str) -> list[PathStr]:
 
 def _parse_awk(command: str) -> list[PathStr]:
     command_parts = tokenize_single_command(command)
+    options = [p for p in command_parts if isinstance(p, Option)]
     positionals = [p.value for p in command_parts if isinstance(p, Positional)]
-    # expect positionals to be ["awk", input1, input2, ...]
-    return positionals[1:]
+    has_script_file = any(p.name == "-f" for p in options)
+    # With -f option: expect ["awk", input1, input2, ...]
+    # Without -f option: expect ["awk", inline_program, input1, input2, ...]
+    return positionals[1:] if has_script_file else positionals[2:]
 
 
 def _parse_nm_piped_command(command: str) -> list[PathStr]:

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -255,7 +255,7 @@ def _parse_pnm_to_logo_command(command: str) -> list[PathStr]:
 
 def _parse_relacheck(command: str) -> list[PathStr]:
     positionals = tokenize_single_command_positionals_only(command)
-    # expect positionals to be ["relachek", input, log_reference]
+    # expect positionals to be ["relacheck", input, log_reference]
     return [positionals[1]]
 
 

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -71,11 +71,11 @@ def _parse_compound_command(command: str) -> list[PathStr]:
             continue
         try:
             input_files += parser(inner_command)
-        except CmdParsingError as e:
+        except (CmdParsingError, IndexError) as e:
             sbom_logging.error(
                 "Skip parsing inner command {inner_command} of compound command because of command parsing error: {error_message}",
                 inner_command=inner_command,
-                error_message=e.message,
+                error_message=str(e),
             )
     return input_files
 
@@ -84,10 +84,6 @@ def _parse_objcopy_command(command: str) -> list[PathStr]:
     command_parts = tokenize_single_command(command, flag_options=["-S", "-w"])
     positionals = [part.value for part in command_parts if isinstance(part, Positional)]
     # expect positionals to be ['objcopy', input_file] or ['objcopy', input_file, output_file]
-    if not (len(positionals) == 2 or len(positionals) == 3):
-        raise CmdParsingError(
-            f"Invalid objcopy command format: expected 2 or 3 positional arguments, got {len(positionals)} ({positionals})"
-        )
     return [positionals[1]]
 
 
@@ -357,7 +353,9 @@ def _parse_bindgen_command(command: str) -> list[PathStr]:
 def _parse_gen_header(command: str) -> list[PathStr]:
     command_parts = shlex.split(command)
     # expect command parts to be ["python3", path/to/gen_headers.py, ..., "--xml", input]
-    i = next(i for i, token in enumerate(command_parts) if token == "--xml")
+    i = next((i for i, token in enumerate(command_parts) if token == "--xml"), None)
+    if i is None:
+        raise CmdParsingError(f"Expected --xml input file in gen_headers command but got {command}")
     return [command_parts[i + 1]]
 
 

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -44,7 +44,7 @@ def _parse_compound_command(command: str) -> list[PathStr]:
         (re.compile(r"sed\b"), _parse_sed_command),
         (
             re.compile(r"(.*/)scripts/bin2c\s*<"),
-            lambda c: [input] if (input := c.split("<")[1].strip()) != "/dev/null" else [],
+            lambda c: [input] if (input := c.split("<")[1].split(">")[0].strip()) != "/dev/null" else [],
         ),
         (re.compile(r"^:$"), _parse_noop),
     ]

--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -122,7 +122,7 @@ def _parse_ar_piped_xargs_command(command: str) -> list[PathStr]:
     printf_command, _ = command.split("|", 1)
     positionals = tokenize_single_command_positionals_only(printf_command.strip())
     # expect positionals to be ['printf', '{prefix_path}%s ', input1, input2, ...]
-    prefix_path = positionals[1].rstrip("%s ")
+    prefix_path = positionals[1].removesuffix("%s ")
     return [f"{prefix_path}{filename}" for filename in positionals[2:]]
 
 

--- a/sbom/sbom/cmd_graph/savedcmd_parser/savedcmd_parser.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/savedcmd_parser.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only OR MIT
 # Copyright (C) 2025 TNG Technology Consulting GmbH
 
-from typing import Any
 import sbom.sbom_logging as sbom_logging
 from sbom.cmd_graph.savedcmd_parser.command_splitter import IfBlock, split_commands
 from sbom.cmd_graph.savedcmd_parser.command_parser_registry import CommandParserRegistry
@@ -28,7 +27,7 @@ def parse_inputs_from_commands(
         list[PathStr]: List of input file paths required by the commands.
     """
 
-    def log_error_or_warning(message: str, /, **kwargs: Any) -> None:
+    def log_error_or_warning(message: str, /, **kwargs: str) -> None:
         if fail_on_unknown_build_command:
             sbom_logging.error(message, **kwargs)
         else:

--- a/sbom/sbom/cmd_graph/savedcmd_parser/savedcmd_parser.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/savedcmd_parser.py
@@ -57,11 +57,11 @@ def parse_inputs_from_commands(
         try:
             inputs = matched_parser(single_command)
             input_files.extend(inputs)
-        except CmdParsingError as e:
+        except (CmdParsingError, IndexError) as e:
             log_error_or_warning(
                 "Skipped parsing command {single_command} because of command parsing error: {error_message}",
                 single_command=single_command,
-                error_message=e.message,
+                error_message=str(e),
             )
 
     return [input.strip().rstrip("/") for input in input_files]

--- a/sbom/sbom/cmd_graph/savedcmd_parser/tokenizer.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/tokenizer.py
@@ -8,9 +8,7 @@ from typing import Union
 
 
 class CmdParsingError(Exception):
-    def __init__(self, message: str):
-        super().__init__(message)
-        self.message = message
+    pass
 
 
 @dataclass

--- a/sbom/sbom/config.py
+++ b/sbom/sbom/config.py
@@ -235,6 +235,8 @@ def get_config() -> KernelSbomConfig:
     if args["roots_file"]:
         with open(args["roots_file"], "rt") as f:
             root_paths = [root.strip() for root in f.readlines()]
+        if len(root_paths) == 0:
+            parser.error("--roots-file must contain at least one path")
     else:
         root_paths = args["roots"]
     _validate_path_arguments(parser, src_tree, obj_tree, root_paths)
@@ -314,5 +316,5 @@ def _validate_path_arguments(
     if not os.path.exists(obj_tree):
         parser.error(f"--obj-tree {obj_tree} does not exist")
     for root_path in root_paths:
-        if not os.path.exists(os.path.join(obj_tree, root_path)):
-            parser.error(f"path to root artifact {os.path.join(obj_tree, root_path)} does not exist")
+        if not os.path.isfile(root_path_absolute := os.path.join(obj_tree, root_path)):
+            parser.error(f"path to root artifact {root_path_absolute} is not a file")

--- a/sbom/sbom/config.py
+++ b/sbom/sbom/config.py
@@ -78,17 +78,13 @@ class KernelSbomConfig:
     """Whether to pretty-print generated SPDX JSON documents."""
 
 
-def _parse_cli_arguments() -> dict[str, Any]:
+def _parse_cli_arguments(parser: argparse.ArgumentParser) -> dict[str, Any]:
     """
     Parse command-line arguments using argparse.
 
     Returns:
         Dictionary of parsed arguments.
     """
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
-        description="Generate SPDX SBOM documents for kernel builds",
-    )
     parser.add_argument(
         "--src-tree",
         default="../linux",
@@ -226,8 +222,11 @@ def get_config() -> KernelSbomConfig:
     Returns:
         KernelSbomConfig: Configuration object with all settings for SBOM generation.
     """
-    # Parse cli arguments
-    args = _parse_cli_arguments()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Generate SPDX SBOM documents for kernel builds",
+    )
+    args = _parse_cli_arguments(parser)
 
     # Extract and validate cli arguments
     src_tree = os.path.realpath(args["src_tree"])
@@ -238,7 +237,7 @@ def get_config() -> KernelSbomConfig:
             root_paths = [root.strip() for root in f.readlines()]
     else:
         root_paths = args["roots"]
-    _validate_path_arguments(src_tree, obj_tree, root_paths)
+    _validate_path_arguments(parser, src_tree, obj_tree, root_paths)
 
     generate_spdx = args["generate_spdx"]
     generate_used_files = args["generate_used_files"]
@@ -295,24 +294,25 @@ def get_config() -> KernelSbomConfig:
     )
 
 
-def _validate_path_arguments(src_tree: PathStr, obj_tree: PathStr, root_paths: list[PathStr]) -> None:
+def _validate_path_arguments(
+    parser: argparse.ArgumentParser,
+    src_tree: PathStr,
+    obj_tree: PathStr,
+    root_paths: list[PathStr],
+) -> None:
     """
     Validate that the provided paths exist.
 
     Args:
+        parser: The argument parser, used to emit well-formatted error messages.
         src_tree: Absolute path to the source tree.
         obj_tree: Absolute path to the object tree.
         root_paths: List of root paths relative to obj_tree.
-
-    Raises:
-        argparse.ArgumentTypeError: If any of the paths don't exist.
     """
     if not os.path.exists(src_tree):
-        raise argparse.ArgumentTypeError(f"--src-tree {src_tree} does not exist")
+        parser.error(f"--src-tree {src_tree} does not exist")
     if not os.path.exists(obj_tree):
-        raise argparse.ArgumentTypeError(f"--obj-tree {obj_tree} does not exist")
+        parser.error(f"--obj-tree {obj_tree} does not exist")
     for root_path in root_paths:
         if not os.path.exists(os.path.join(obj_tree, root_path)):
-            raise argparse.ArgumentTypeError(
-                f"path to root artifact {os.path.join(obj_tree, root_path)} does not exist"
-            )
+            parser.error(f"path to root artifact {os.path.join(obj_tree, root_path)} does not exist")

--- a/sbom/sbom/config.py
+++ b/sbom/sbom/config.py
@@ -3,7 +3,7 @@
 
 import argparse
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import os
 from typing import Any
@@ -250,7 +250,8 @@ def get_config() -> KernelSbomConfig:
     write_output_on_error = args["write_output_on_error"]
 
     created = datetime.fromtimestamp(
-        max([os.path.getmtime(os.path.join(obj_tree, root_path)) for root_path in root_paths])
+        max([os.path.getmtime(os.path.join(obj_tree, root_path)) for root_path in root_paths]),
+        tz=timezone.utc,
     )
     spdxId_prefix = args["spdxId_prefix"]
     build_type = args["build_type"]

--- a/sbom/sbom/path_utils.py
+++ b/sbom/sbom/path_utils.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2025 TNG Technology Consulting GmbH
 
 import os
+from functools import lru_cache
 
 PathStr = str
 """Filesystem path represented as a plain string for better performance than pathlib.Path."""
@@ -9,3 +10,13 @@ PathStr = str
 
 def is_relative_to(path: PathStr, base: PathStr) -> bool:
     return os.path.commonpath([path, base]) == base
+
+@lru_cache(maxsize=None)
+def has_link(path: PathStr) -> bool:
+    """Returns True if path or any of its ancestor directories is a symlink. Results are cached to avoid duplicate lstat syscalls."""
+    if os.path.islink(path):
+        return True
+    parent = os.path.dirname(path)
+    if parent == path:
+        return False
+    return has_link(parent)

--- a/sbom/sbom/sbom_logging.py
+++ b/sbom/sbom/sbom_logging.py
@@ -3,7 +3,7 @@
 
 import logging
 import inspect
-from typing import Any, Literal
+from typing import Literal
 
 
 class MessageLogger:
@@ -19,9 +19,11 @@ class MessageLogger:
         self.messages = {}
         self.repeated_logs_limit = repeated_logs_limit
 
-    def log(self, template: str, /, **kwargs: Any) -> None:
+    def log(self, template: str, /, **kwargs: str) -> None:
         """Log a message based on a template and optional variables."""
-        message = template.format(**kwargs)
+        message = template
+        for key, value in kwargs.items():
+            message = message.replace("{" + key + "}", value)
         if template not in self.messages:
             self.messages[template] = []
         if len(self.messages[template]) < self.repeated_logs_limit:
@@ -52,12 +54,12 @@ _warning_logger: MessageLogger
 _error_logger: MessageLogger
 
 
-def warning(msg_template: str, /, **kwargs: Any) -> None:
+def warning(msg_template: str, /, **kwargs: str) -> None:
     """Log a warning message."""
     _warning_logger.log(msg_template, **kwargs)
 
 
-def error(msg_template: str, /, **kwargs: Any) -> None:
+def error(msg_template: str, /, **kwargs: str) -> None:
     """Log an error message including file, line, and function context."""
     frame = inspect.currentframe()
     caller_frame = frame.f_back if frame else None

--- a/sbom/sbom/spdx/build.py
+++ b/sbom/sbom/spdx/build.py
@@ -12,6 +12,6 @@ class Build(Element):
     type: str = field(init=False, default="build_Build")
     build_buildType: str
     build_buildId: str
-    build_environment: list[DictionaryEntry] = field(default_factory=list[DictionaryEntry])
-    build_configSourceUri: list[str] = field(default_factory=list[str])
-    build_configSourceDigest: list[Hash] = field(default_factory=list[Hash])
+    build_environment: list[DictionaryEntry] = field(default_factory=list)
+    build_configSourceUri: list[str] = field(default_factory=list)
+    build_configSourceDigest: list[Hash] = field(default_factory=list)

--- a/sbom/sbom/spdx/core.py
+++ b/sbom/sbom/spdx/core.py
@@ -33,7 +33,7 @@ class SpdxObject:
         d: dict[str, Any] = {}
         for field_name in self.__dataclass_fields__:
             value = getattr(self, field_name)
-            if not value:
+            if value is None or value == [] or value == "":
                 continue
 
             if isinstance(value, Element):

--- a/sbom/sbom/spdx/core.py
+++ b/sbom/sbom/spdx/core.py
@@ -68,7 +68,7 @@ class Element(SpdxObject):
     spdxId: SpdxId
     creationInfo: str = "_:creationinfo"
     name: str | None = None
-    verifiedUsing: list[Hash] = field(default_factory=list[Hash])
+    verifiedUsing: list[Hash] = field(default_factory=list)
     comment: str | None = None
 
 
@@ -94,9 +94,9 @@ class ElementCollection(Element):
     """https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/"""
 
     type: str = field(init=False, default="ElementCollection")
-    element: list[Element] = field(default_factory=list[Element])
-    rootElement: list[Element] = field(default_factory=list[Element])
-    profileConformance: list[ProfileIdentifierType] = field(default_factory=list[ProfileIdentifierType])
+    element: list[Element] = field(default_factory=list)
+    rootElement: list[Element] = field(default_factory=list)
+    profileConformance: list[ProfileIdentifierType] = field(default_factory=list)
 
 
 @dataclass(kw_only=True)
@@ -104,8 +104,8 @@ class SpdxDocument(ElementCollection):
     """https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/SpdxDocument/"""
 
     type: str = field(init=False, default="SpdxDocument")
-    import_: list[ExternalMap] = field(default_factory=list[ExternalMap])
-    namespaceMap: list[NamespaceMap] = field(default_factory=list[NamespaceMap])
+    import_: list[ExternalMap] = field(default_factory=list)
+    namespaceMap: list[NamespaceMap] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {("import" if k == "import_" else k): v for k, v in super().to_dict().items()}

--- a/sbom/sbom/spdx/serialization.py
+++ b/sbom/sbom/spdx/serialization.py
@@ -10,7 +10,6 @@ from sbom.spdx.core import SPDX_SPEC_VERSION, SpdxDocument, SpdxObject
 class JsonLdSpdxDocument:
     """Represents an SPDX document in JSON-LD format for serialization."""
 
-    context: list[str | dict[str, str]]
     graph: list[SpdxObject]
 
     def __init__(self, graph: list[SpdxObject]) -> None:
@@ -22,12 +21,14 @@ class JsonLdSpdxDocument:
             graph: List of SPDX objects representing the complete SPDX document.
         """
         self.graph = graph
-        spdx_document = next(element for element in graph if isinstance(element, SpdxDocument))
-        self.context = [
+
+    @property
+    def context(self) -> list[str | dict[str, str]]:
+        spdx_document = next(element for element in self.graph if isinstance(element, SpdxDocument))
+        return [
             f"https://spdx.org/rdf/{SPDX_SPEC_VERSION}/spdx-context.jsonld",
-            {namespaceMap.prefix: namespaceMap.namespace for namespaceMap in spdx_document.namespaceMap},
+            {ns.prefix: ns.namespace for ns in spdx_document.namespaceMap},
         ]
-        spdx_document.namespaceMap = []
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -36,9 +37,14 @@ class JsonLdSpdxDocument:
         Returns:
             Dictionary with @context and @graph keys following JSON-LD format.
         """
+        def _item_to_dict(item: SpdxObject) -> dict:
+            d = item.to_dict()
+            if isinstance(item, SpdxDocument):
+                d.pop("namespaceMap", None)
+            return d
         return {
             "@context": self.context,
-            "@graph": [item.to_dict() for item in self.graph],
+            "@graph": [_item_to_dict(item) for item in self.graph],
         }
 
     def save(self, path: PathStr, prettify: bool) -> None:

--- a/sbom/sbom/spdx/software.py
+++ b/sbom/sbom/spdx/software.py
@@ -29,7 +29,7 @@ class Sbom(ElementCollection):
     """https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Classes/Sbom/"""
 
     type: str = field(init=False, default="software_Sbom")
-    software_sbomType: list[SbomType] = field(default_factory=list[SbomType])
+    software_sbomType: list[SbomType] = field(default_factory=list)
 
 
 @dataclass(kw_only=True)
@@ -48,7 +48,7 @@ class SoftwareArtifact(Artifact):
     type: str = field(init=False, default="software_Artifact")
     software_primaryPurpose: SoftwarePurpose | None = None
     software_copyrightText: str | None = None
-    software_contentIdentifier: list[ContentIdentifier] = field(default_factory=list[ContentIdentifier])
+    software_contentIdentifier: list[ContentIdentifier] = field(default_factory=list)
 
 
 @dataclass(kw_only=True)

--- a/sbom/sbom/spdx_graph/build_spdx_graphs.py
+++ b/sbom/sbom/spdx_graph/build_spdx_graphs.py
@@ -60,6 +60,7 @@ def build_spdx_graphs(
     if len(kernel_files.source) > 0:
         spdx_graphs[KernelSpdxDocumentKind.SOURCE] = SpdxSourceGraph.create(
             source_files=list(kernel_files.source.values()),
+            external_files=list(kernel_files.external.values()),
             shared_elements=shared_elements,
             spdx_id_generators=spdx_id_generators,
         )

--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -201,27 +201,33 @@ def _git_blob_oid(file_path: str, chunk_size: int = 1 << 20) -> str:
 
 
 # REUSE-IgnoreStart
-SPDX_LICENSE_IDENTIFIER_PATTERN = re.compile(r"SPDX-License-Identifier:\s*(?P<id>.*?)(?:\s*(\*/|$))")
+SPDX_LICENSE_IDENTIFIER_PATTERN = re.compile(
+    r"SPDX-License-Identifier:"   # literal tag
+    r"\s*"                        # optional whitespace after colon
+    r"(?P<id>.*?)"                # license expression (non-greedy, stops before terminator)
+    r"(?:\s*"                     # optional whitespace before terminator (not captured)
+    r"(-->|\*/|$))",              # terminator: XML "-->", C-style "*/", or end of line
+    re.MULTILINE,                 # match end of each line, not just end of string
+)
 # REUSE-IgnoreEnd
 
 
-def _parse_spdx_license_identifier(absolute_path: str, max_lines: int = 5) -> str | None:
+def _parse_spdx_license_identifier(absolute_path: str, max_bytes: int = 512) -> str | None:
     """
-    Extracts the SPDX-License-Identifier from the first few lines of a source file.
+    Extracts the SPDX-License-Identifier from the beginning of a source file.
 
     Args:
         absolute_path: Path to the source file.
-        max_lines: Number of lines to scan from the top (default: 5).
+        max_bytes: Maximum number of bytes to scan for the license identifier.
 
     Returns:
         The license identifier string (e.g., 'GPL-2.0-only') if found, otherwise None.
     """
     try:
         with open(absolute_path, "r") as f:
-            for _ in range(max_lines):
-                match = SPDX_LICENSE_IDENTIFIER_PATTERN.search(f.readline())
-                if match:
-                    return match.group("id")
+            match = SPDX_LICENSE_IDENTIFIER_PATTERN.search(f.read(max_bytes))
+            if match:
+                return match.group("id")
     except (UnicodeDecodeError, OSError):
         return None
     return None

--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -64,7 +64,7 @@ class KernelFile:
         if not is_in_src_tree and not is_in_obj_tree:
             file_element_name = str(absolute_path)
             file_location = KernelFileLocation.EXTERNAL
-            spdx_id_generator = spdx_id_generators.build
+            spdx_id_generator = spdx_id_generators.source if src_tree != obj_tree else spdx_id_generators.build
         elif is_in_src_tree and src_tree == obj_tree:
             file_element_name = os.path.relpath(absolute_path, obj_tree)
             file_location = KernelFileLocation.BOTH
@@ -112,6 +112,7 @@ class KernelFileCollection:
     source: dict[PathStr, KernelFile]
     build: dict[PathStr, KernelFile]
     output: dict[PathStr, KernelFile]
+    external: dict[PathStr, KernelFile]
 
     @classmethod
     def create(
@@ -124,6 +125,7 @@ class KernelFileCollection:
         source: dict[PathStr, KernelFile] = {}
         build: dict[PathStr, KernelFile] = {}
         output: dict[PathStr, KernelFile] = {}
+        external: dict[PathStr, KernelFile] = {}
         root_node_paths = {node.absolute_path for node in cmd_graph.roots}
         for node in cmd_graph:
             is_root = node.absolute_path in root_node_paths
@@ -138,13 +140,15 @@ class KernelFileCollection:
                 output[kernel_file.absolute_path] = kernel_file
             elif kernel_file.file_location == KernelFileLocation.SOURCE_TREE:
                 source[kernel_file.absolute_path] = kernel_file
+            elif kernel_file.file_location == KernelFileLocation.EXTERNAL:
+                external[kernel_file.absolute_path] = kernel_file
             else:
                 build[kernel_file.absolute_path] = kernel_file
 
-        return KernelFileCollection(source, build, output)
+        return KernelFileCollection(source, build, output, external)
 
     def to_dict(self) -> dict[PathStr, KernelFile]:
-        return {**self.source, **self.build, **self.output}
+        return {**self.source, **self.build, **self.output, **self.external}
 
 
 def _build_file_element(absolute_path: PathStr, name: str, spdx_id: SpdxId, file_location: KernelFileLocation) -> File:

--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -150,7 +150,7 @@ class KernelFileCollection:
 def _build_file_element(absolute_path: PathStr, name: str, spdx_id: SpdxId, file_location: KernelFileLocation) -> File:
     verifiedUsing: list[Hash] = []
     content_identifier: list[ContentIdentifier] = []
-    if os.path.exists(absolute_path):
+    if os.path.isfile(absolute_path):
         verifiedUsing = [Hash(algorithm="sha256", hashValue=_sha256(absolute_path))]
         content_identifier = [
             ContentIdentifier(

--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -181,29 +181,23 @@ def _build_file_element(absolute_path: PathStr, name: str, spdx_id: SpdxId, file
     )
 
 
-def _sha256(path: PathStr) -> str:
-    """Compute the SHA-256 hash of a file."""
-    with open(path, "rb") as f:
-        data = f.read()
-    return hashlib.sha256(data).hexdigest()
-
-
-def _git_blob_oid(file_path: str) -> str:
-    """
-    Compute the Git blob object ID (SHA-1) for a file, like `git hash-object`.
-
-    Args:
-        file_path: Path to the file.
-
-    Returns:
-        SHA-1 hash (hex) of the Git blob object.
-    """
+def _sha256(file_path: PathStr, chunk_size: int = 1 << 20) -> str:
+    """Compute the SHA-256 hex digest of a file, reading it in chunks of chunk_size bytes."""
+    h = hashlib.sha256()
     with open(file_path, "rb") as f:
-        content = f.read()
-    header = f"blob {len(content)}\0".encode()
-    store = header + content
-    sha1_hash = hashlib.sha1(store).hexdigest()
-    return sha1_hash
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _git_blob_oid(file_path: str, chunk_size: int = 1 << 20) -> str:
+    """Compute the Git blob object ID (SHA-1 hex) for a file, like `git hash-object`, reading it in chunks of chunk_size bytes."""
+    h = hashlib.sha1()
+    h.update(f"blob {os.path.getsize(file_path)}\0".encode())
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 # REUSE-IgnoreStart

--- a/sbom/sbom/spdx_graph/shared_spdx_elements.py
+++ b/sbom/sbom/spdx_graph/shared_spdx_elements.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2025 TNG Technology Consulting GmbH
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from sbom.spdx.core import CreationInfo, SoftwareAgent
 from sbom.spdx.spdxId import SpdxIdGenerator
 
@@ -28,5 +28,5 @@ class SharedSpdxElements:
             spdxId=spdx_id_generator.generate(),
             name="KernelSbom",
         )
-        creation_info = CreationInfo(createdBy=[agent], created=created.strftime("%Y-%m-%dT%H:%M:%SZ"))
+        creation_info = CreationInfo(createdBy=[agent], created=created.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
         return SharedSpdxElements(agent=agent, creation_info=creation_info)

--- a/sbom/sbom/spdx_graph/spdx_build_graph.py
+++ b/sbom/sbom/spdx_graph/spdx_build_graph.py
@@ -117,8 +117,8 @@ def _create_spdx_build_graph(
 
     build_spdx_document.import_ = [
         *(
-            ExternalMap(externalSpdxId=file_element.spdx_file_element.spdxId)
-            for file_element in kernel_files.source.values()
+            ExternalMap(externalSpdxId=file.spdx_file_element.spdxId)
+            for file in (*kernel_files.source.values(), *kernel_files.external.values())
         ),
         ExternalMap(externalSpdxId=high_level_build_element.spdxId),
         *(ExternalMap(externalSpdxId=file.spdx_file_element.spdxId) for file in kernel_files.output.values()),
@@ -191,6 +191,7 @@ def _create_spdx_build_graph_with_mixed_sources(
 
     # File elements
     build_file_elements = [file.spdx_file_element for file in kernel_files.build.values()]
+    external_file_elements = [file.spdx_file_element for file in kernel_files.external.values()]
     file_relationships = _file_relationships(
         cmd_graph=cmd_graph,
         file_elements={key: file.spdx_file_element for key, file in kernel_files.to_dict().items()},
@@ -214,6 +215,7 @@ def _create_spdx_build_graph_with_mixed_sources(
     build_sbom.rootElement = [*root_file_elements]
     build_sbom.element = [
         *build_file_elements,
+        *external_file_elements,
         *source_file_license_identifiers,
         *source_file_license_relationships,
         *file_relationships,

--- a/sbom/sbom/spdx_graph/spdx_source_graph.py
+++ b/sbom/sbom/spdx_graph/spdx_source_graph.py
@@ -19,12 +19,14 @@ class SpdxSourceGraph(SpdxGraph):
     def create(
         cls,
         source_files: list[KernelFile],
+        external_files: list[KernelFile],
         shared_elements: SharedSpdxElements,
         spdx_id_generators: SpdxIdGeneratorCollection,
     ) -> "SpdxSourceGraph":
         """
         Args:
             source_files: List of files within the kernel source tree.
+            external_files: Files outside both source and object trees.
             shared_elements: Shared SPDX elements used across multiple documents.
             spdx_id_generators: Collection of SPDX ID generators.
 
@@ -63,6 +65,7 @@ class SpdxSourceGraph(SpdxGraph):
 
         # Source file elements
         source_file_elements: list[Element] = [file.spdx_file_element for file in source_files]
+        external_file_elements: list[Element] = [file.spdx_file_element for file in external_files]
 
         # Source file license elements
         source_file_license_identifiers, source_file_license_relationships = source_file_license_elements(
@@ -76,6 +79,7 @@ class SpdxSourceGraph(SpdxGraph):
             src_tree_element,
             src_tree_contains_relationship,
             *source_file_elements,
+            *external_file_elements,
             *source_file_license_identifiers,
             *source_file_license_relationships,
         ]

--- a/sbom/tests/cmd_graph/test_savedcmd_parser.py
+++ b/sbom/tests/cmd_graph/test_savedcmd_parser.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+from unittest.mock import patch
 
 from sbom.cmd_graph.savedcmd_parser import parse_inputs_from_commands
 from sbom.cmd_graph.savedcmd_parser.command_parser_registry import CommandParserRegistry
@@ -113,12 +114,12 @@ class TestSavedCmdParser(unittest.TestCase):
         self._assert_parsing(cmd, expected)
 
     def test_gcc_with_env_override(self):
-        os.environ["CC"] = "ccache gcc"
-        registry = CommandParserRegistry.create()
-        cmd = "gcc   -o arch/x86/tools/relocs arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
-        expected = "arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
-        self._assert_parsing(cmd, expected, registry)
-        self._assert_parsing(f"ccache {cmd}", expected, registry)
+        with patch.dict(os.environ, {"CC": "ccache gcc"}):
+            registry = CommandParserRegistry.create()
+            cmd = "gcc   -o arch/x86/tools/relocs arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
+            expected = "arch/x86/tools/relocs_32.o arch/x86/tools/relocs_64.o arch/x86/tools/relocs_common.o"
+            self._assert_parsing(cmd, expected, registry)
+            self._assert_parsing(f"ccache {cmd}", expected, registry)
 
     def test_gcc_dts_preprocessing(self):
         cmd = "gcc -E -Wp,-MMD,drivers/of/.empty_root.dtb.d.pre.tmp -nostdinc -I ../scripts/dtc/include-prefixes -undef -D__DTS__ -x assembler-with-cpp -o drivers/of/.empty_root.dtb.dts.tmp ../drivers/of/empty_root.dts"
@@ -137,12 +138,12 @@ class TestSavedCmdParser(unittest.TestCase):
         self._assert_parsing(cmd, expected)
 
     def test_ld_with_env_override(self):
-        os.environ["LD"] = "some-tool ld"
-        registry = CommandParserRegistry.create()
-        cmd = 'ld -o arch/x86/entry/vdso/vdso64.so.dbg -shared --hash-style=both --build-id=sha1 --no-undefined  --eh-frame-hdr -Bsymbolic -z noexecstack -m elf_x86_64 -soname linux-vdso.so.1 -z max-page-size=4096 -T arch/x86/entry/vdso/vdso.lds arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o; if readelf -rW arch/x86/entry/vdso/vdso64.so.dbg | grep -v _NONE | grep -q " R_\w*_"; then (echo >&2 "arch/x86/entry/vdso/vdso64.so.dbg: dynamic relocations are not supported"; rm -f arch/x86/entry/vdso/vdso64.so.dbg; /bin/false); fi'  # type: ignore
-        expected = "arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o"
-        self._assert_parsing(cmd, expected, registry)
-        self._assert_parsing(f"some-tool {cmd}", expected, registry)
+        with patch.dict(os.environ, {"LD": "some-tool ld"}):
+            registry = CommandParserRegistry.create()
+            cmd = 'ld -o arch/x86/entry/vdso/vdso64.so.dbg -shared --hash-style=both --build-id=sha1 --no-undefined  --eh-frame-hdr -Bsymbolic -z noexecstack -m elf_x86_64 -soname linux-vdso.so.1 -z max-page-size=4096 -T arch/x86/entry/vdso/vdso.lds arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o; if readelf -rW arch/x86/entry/vdso/vdso64.so.dbg | grep -v _NONE | grep -q " R_\w*_"; then (echo >&2 "arch/x86/entry/vdso/vdso64.so.dbg: dynamic relocations are not supported"; rm -f arch/x86/entry/vdso/vdso64.so.dbg; /bin/false); fi'  # type: ignore
+            expected = "arch/x86/entry/vdso/vdso-note.o arch/x86/entry/vdso/vclock_gettime.o arch/x86/entry/vdso/vgetcpu.o arch/x86/entry/vdso/vgetrandom.o arch/x86/entry/vdso/vgetrandom-chacha.o"
+            self._assert_parsing(cmd, expected, registry)
+            self._assert_parsing(f"some-tool {cmd}", expected, registry)
 
     def test_ld_whole_archive(self):
         cmd = "ld -m elf_x86_64 -z noexecstack -r -o vmlinux.o   --whole-archive vmlinux.a --no-whole-archive --start-group  --end-group"

--- a/sbom/tests/spdx_graph/test_kernel_file.py
+++ b/sbom/tests/spdx_graph/test_kernel_file.py
@@ -22,6 +22,7 @@ class TestKernelFile(unittest.TestCase):
             ("// SPDX-License-Identifier: GPL-2.0-only", "GPL-2.0-only"),
             ("/* SPDX-License-Identifier: GPL-2.0-or-later OR MIT */", "GPL-2.0-or-later OR MIT"),
             ("/* SPDX-License-Identifier: Apache-2.0 */\n extra text", "Apache-2.0"),
+            ("<!-- SPDX-License-Identifier: GPL-2.0 -->", "GPL-2.0"),
             ("int main() { return 0; }", None),
         ]
         # REUSE-IgnoreEnd

--- a/sbom_integration_tests/data/target-sbom-build.spdx.json
+++ b/sbom_integration_tests/data/target-sbom-build.spdx.json
@@ -2,10 +2,10 @@
   "@context": [
     "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
     {
-      "b": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/build/",
-      "s": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/source/",
-      "o": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/output/",
-      "p": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/"
+      "b": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/build/",
+      "s": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/source/",
+      "o": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/output/",
+      "p": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/"
     }
   ],
   "@graph": [
@@ -61,7 +61,7 @@
       "createdBy": [
         "p:0"
       ],
-      "created": "2025-12-11T07:54:56Z"
+      "created": "2026-05-03T18:50:54Z"
     },
     {
       "type": "software_Sbom",

--- a/sbom_integration_tests/data/target-sbom-output.spdx.json
+++ b/sbom_integration_tests/data/target-sbom-output.spdx.json
@@ -2,8 +2,8 @@
   "@context": [
     "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
     {
-      "o": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/output/",
-      "p": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/"
+      "o": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/output/",
+      "p": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/"
     }
   ],
   "@graph": [
@@ -34,7 +34,7 @@
       "createdBy": [
         "p:0"
       ],
-      "created": "2025-12-11T07:54:56Z"
+      "created": "2026-05-03T18:50:54Z"
     },
     {
       "type": "software_Sbom",

--- a/sbom_integration_tests/data/target-sbom-source.spdx.json
+++ b/sbom_integration_tests/data/target-sbom-source.spdx.json
@@ -2,8 +2,8 @@
   "@context": [
     "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
     {
-      "s": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/source/",
-      "p": "urn:spdx.dev:5b5d1487-cef1-5aa8-a8ee-c680b6726afb/"
+      "s": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/source/",
+      "p": "urn:spdx.dev:78b8dda0-35a0-5150-aa95-a3f3ef95de52/"
     }
   ],
   "@graph": [
@@ -33,7 +33,7 @@
       "createdBy": [
         "p:0"
       ],
-      "created": "2025-12-11T07:54:56Z"
+      "created": "2026-05-03T18:50:54Z"
     },
     {
       "type": "software_Sbom",

--- a/sbom_integration_tests/test_sbom.py
+++ b/sbom_integration_tests/test_sbom.py
@@ -4,7 +4,7 @@
 # pyright: reportMissingImports=false
 # ruff: noqa: E402
 
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 import sys
@@ -39,7 +39,7 @@ class TestSbom(unittest.TestCase):
             graph = json.load(f)["@graph"]
         creation = next(item for item in graph if item.get("type") == "CreationInfo")
         created_str: str = creation["created"]
-        dt = datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%SZ")
+        dt = datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
         mtime = dt.timestamp()
         bzimage = Path(data_path) / "linux/kernel_build/arch/x86/boot/bzImage"
         os.utime(bzimage, (mtime, mtime))


### PR DESCRIPTION
This PR addresses issues highlighted by the AI review in 
https://sashiko.dev/#/patchset/20260410212255.9883-1-luis.augenstein@tngtech.com 

Most changes are **Robustness** related, i.e., things that didn't cause any failure so far but could so in the future when assumptions change, new functionality is added, or uncommon user inputs are encountered. 

Additionally, Sashiko found 3 actual Bugs that caused wrong SBOM outputs.

---

## Patch 3 - `scripts/sbom: setup sbom logging`

- **[Robustness]** [1848fc4](https://github.com/TNG/KernelSbom/commit/1848fc47acee4d3755a7fe1f5d5a532a52a40ad7) — Improve logging robustness by accounting for templates that include literal curly brackets.

---

## Patch 4 — `scripts/sbom: add command parsers`

- **[Robustness]** [ed95bb7](https://github.com/TNG/KernelSbom/commit/ed95bb7045b2520d3df001126ce623687429b3f9) — Improve parsing robustness by accounting for redirects of `bin2c` commands into an output file (`< input > output`).
- **[Robustness]** [1f3aa13](https://github.com/TNG/KernelSbom/commit/1f3aa13773cf731472ff5a354be74d4179bc76e0) — Improve parsing robustness for `printf '<some_path>/%s ' | xargs ar` commands where trailing `s` characters of `<some_path>` would have been removed. Replace incorrect usage of `rstrip` with `removesuffix`.
- **[Robustness]** [28ee708](https://github.com/TNG/KernelSbom/commit/28ee7089d519ab32a662b41c1051ba3897feb578) — Improve parsing robustness by catching `IndexError` in command parsers in case command invocation assumptions don't hold.
- **[Robustness]** [85b49f0](https://github.com/TNG/KernelSbom/commit/85b49f01d69a2f08a0c633dd297f1d5ee5fb65cb) — Improve parsing robustness for `awk` commands when an inline program argument (e.g. `'{print $1}'`) is used.

---

## Patch 5 — `scripts/sbom: add cmd graph generation`

- **[Info Log Typo]** [4a5089a](https://github.com/TNG/KernelSbom/commit/4a5089a48224c069083d156e8e26a6347457c114) — Remove a trailing comma inside an f-string interpolation that caused the log message to print a tuple `('filename.txt',)` instead of the bare filename string.
- **[Robustness]** [c393b43](https://github.com/TNG/KernelSbom/commit/c393b43f57027c92d151d058280ca501d58c6801) — Improve robustness of `.cmd` file parsing and provide clear error messages where previously a generic `IndexError` was raised when cmd file structure assumptions didn't hold.
- **[Bug]** [2a8efdc](https://github.com/TNG/KernelSbom/commit/2a8efdcb090a5b2bf9dc922b7f5cfbb9a0bec432) — Relative paths with symlinks are now properly resolved. Previously the same file could occur multiple times in the sbom if it was referenced both through a symlink path and the canonical path or two different symlink paths. Note:  `os.path.realpath` is still only used when strictly necessary due to its significant performance impact.
- **[Robustness]** [b18d3c6](https://github.com/TNG/KernelSbom/commit/b18d3c64b7a919415ff433358a85379497dec471) — Improve deps parsing robustness by relaxing the `VALID_PATH_PATTERN` regex to also accept characters such as `+`, `~`, `=`, and `@` that can appear in legitimate kernel build paths.
- **[Robustness]** [cbbaae7](https://github.com/TNG/KernelSbom/commit/cbbaae7cab1ec6477a9a8e85a0b6be3c362a251a) — Use proper argparse error handling instead of raising generic exceptions for invalid user-provided arguments.

---

## Patch 6 — `scripts/sbom: add additional dependency sources for cmd graph`

- **[Pythonic Syntax]** [c84a3a2](https://github.com/TNG/KernelSbom/commit/c84a3a2a4b4722504836678011ca8c9a0ebe2f56) — Use proper pythonic `list` constructor in `dataclass default_factory` instead of a generic type alias.
- **[Robustness]** [f8a1d55](https://github.com/TNG/KernelSbom/commit/f8a1d55eccfc17b9041a714605c3867f617c9543) — Improve path resolution robustness for hardcoded dependencies with paths in the source tree.

---

## Patch 7 — `scripts/sbom: add SPDX classes`

- **[Robustness]** [fded697](https://github.com/TNG/KernelSbom/commit/fded697874da21b3454921edfbfca11b63608acb) — Make the `to_dict` field filter use explicit `is None` / empty-list checks instead of plain truthiness tests, so that legitimate falsy values such as `0` or `False` are not silently omitted from the serialized SPDX output.
- **[Robustness]** [4c89521](https://github.com/TNG/KernelSbom/commit/4c89521c18216143d4e605d55644b53e732fa602) — Avoid mutating the caller's SPDX object when constructing the `JsonLdDocument` by not clearing `namespaceMap` on the original element, preventing data loss if the graph is reused after serialization.

---

## Patch 9 — `scripts/sbom: add shared SPDX elements`

- **[Robustness]** [7012e72](https://github.com/TNG/KernelSbom/commit/7012e72826952ca2f0065c1d9ac5a0ed88e0ac81) — Add an explicit validation step for `--roots-file` that rejects an empty file early.
- **[Bug]** [fb2ae60](https://github.com/TNG/KernelSbom/commit/fb2ae60028035a89289fd4ea1b0bdba732cd96bb) — Use a timezone-aware UTC `datetime` when recording the SBOM creation timestamp. Previously the local system timezone was used.

---

## Patch 10 — `scripts/sbom: collect file metadata`

- **[Robustness]** [be33b54](https://github.com/TNG/KernelSbom/commit/be33b546c2043d9d92059a3a0cb815e2c6e679fa) — Replace `os.path.exists()` with `os.path.isfile()` before computing file hashes, so that directory nodes appearing in `.cmd` dependency lists are skipped rather than triggering an `IsADirectoryError`.
- **[Robustness]** [d30d360](https://github.com/TNG/KernelSbom/commit/d30d360225a8fb381c98b6b4e1cc07b3527ab061) — Stream file content in fixed-size chunks when computing SHA-256 and git blob OIDs, reducing memory consumption on large build artifacts such as `vmlinux` or `bzImage`.
- **[Robustness]** [1435e78](https://github.com/TNG/KernelSbom/commit/1435e78749de623f7294a0a4a69e7a8ceb716a50) — Extend the `SPDX-License-Identifier` regex to also handle XML comment terminators (`-->`) in captured license expressions.

---

## Patch 13 — `scripts/sbom: add SPDX build graph`

- **[Bug]** [9f2f3d4](https://github.com/TNG/KernelSbom/commit/9f2f3d470cd8735eb7b35153e59fb3a7ca4435bc) — Correctly assign external files outside both the source and object tree (e.g. Rust core libraries) to the source SBOM rather than the build SBOM. Previously, external files were incorrectly declared as contained within the object-tree directory via an SPDX `contains` relationship.

---

## Patch 14 — `scripts/sbom: add unit tests for command parsers`

- **[Robustness]** [ccb005c](https://github.com/TNG/KernelSbom/commit/ccb005c4f07e53e112a4f33ef87e761ac60afc2b) — Replace direct `os.environ` assignments in unit tests with `unittest.mock.patch.dict` so that environment variable changes are automatically restored after each test, eliminating cross-test pollution.


---

Successful Workflow Run https://github.com/TNG/KernelSbom/actions/runs/25318807807
