### PR TITLE
Primary Purpose Estimation for mach-types and piggy_data

### DIFF
--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -253,7 +253,7 @@ def _get_primary_purpose(absolute_path: PathStr) -> SoftwarePurpose | None:
         return "library"
 
     # Archives
-    if ends_with([".xz", ".cpio", ".gz", ".tar", ".zip"]):
+    if ends_with([".xz", ".cpio", ".gz", ".tar", ".zip", "piggy_data"]):
         return "archive"
 
     # Applications
@@ -295,6 +295,7 @@ def _get_primary_purpose(absolute_path: PathStr) -> SoftwarePurpose | None:
             "x509_revocation_list",
             "cpucaps",
             "sysreg",
+            "mach-types",
         ]
     ) or includes_path_segments(["drivers/gpu/drm/radeon/reg_srcs/"]):
         return "data"


### PR DESCRIPTION
Follow up for https://github.com/TNG/KernelSbom/pull/125 which added command parsers for `syscallnr.sh` and `mkuboot.sh` allowing the following command to succeed without errors:
```bash
make -j$(nproc) O=kernel_build ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- KBUILD_IMAGE=arch/arm/boot/uImage LOADADDR=0x80008000 defconfig  sbom
```
With these command parsers in place the dependency graph reaches new files which are not in the primary purpose mapping yet:
```bash
[WARNING] Could not infer primary purpose for /home/luis/code/WSKernelSbom/augelu-tng/linux/arch/arm/tools/mach-types
[WARNING] Could not infer primary purpose for /home/luis/code/WSKernelSbom/augelu-tng/linux/kernel_build/arch/arm/boot/compressed/piggy_data
```
This PR adds the new files to the primary purpose mapping. 