### PR TITLE
Add Command Parser for gen-kernel-hwcaps.sh

### DIFF
--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -390,6 +390,13 @@ def _parse_syscallnr_command(command: str) -> list[PathStr]:
     return [positionals[2]]
 
 
+def _parse_gen_kernel_hwcaps_command(command: str) -> list[PathStr]:
+    command_parts = tokenize_single_command(command.strip(), flag_options=["-e"])
+    positionals = [p.value for p in command_parts if isinstance(p, Positional)]
+    # expect positionals to be ["sh", path/to/gen-kernel-hwcaps.sh, input]
+    return [positionals[2]]
+
+
 class CommandParserRegistry:
     """
     Registry mapping command patterns to their input-file parsers.
@@ -483,6 +490,7 @@ class CommandParserRegistry:
             (re.compile(r"sh (.*/)?checkundef\.sh\b"), _parse_noop),
             (re.compile(r"(bash|sh) (.*/)?mkuboot\.sh\b"), _parse_mkuboot_command),
             (re.compile(r"sh (.*/)?syscallnr\.sh\b"), _parse_syscallnr_command),
+            (re.compile(r"(/bin/)?sh (.*/)?gen-kernel-hwcaps\.sh\b"), lambda c: _parse_gen_kernel_hwcaps_command(c.split(">")[0])),
             (re.compile(r"(.*/)?vdso2c\b"), _parse_vdso2c_command),
             (re.compile(r"(.*/)?vdsomunge\b"), _parse_vdsomunge_command),
             (re.compile(r"^(.*/)?mkpiggy.*?>"), _parse_mkpiggy_command),

--- a/sbom/tests/cmd_graph/test_savedcmd_parser.py
+++ b/sbom/tests/cmd_graph/test_savedcmd_parser.py
@@ -329,6 +329,12 @@ class TestSavedCmdParser(unittest.TestCase):
         expected = "../arch/arm/tools/syscall.tbl"
         self._assert_parsing(cmd, expected)
 
+    # gen-kernel-hwcaps.sh command tests
+    def test_gen_kernel_hwcaps(self):
+        cmd = "/bin/sh -e ../arch/arm64/tools/gen-kernel-hwcaps.sh ../arch/arm64/include/uapi/asm/hwcap.h > arch/arm64/include/generated/asm/kernel-hwcap.h"
+        expected = "../arch/arm64/include/uapi/asm/hwcap.h"
+        self._assert_parsing(cmd, expected)
+
     # vdso2c command tests
     def test_vdso2c(self):
         cmd = "arch/x86/entry/vdso/vdso2c arch/x86/entry/vdso/vdso64.so.dbg arch/x86/entry/vdso/vdso64.so arch/x86/entry/vdso/vdso-image-64.c"


### PR DESCRIPTION
New command parser for `gen-kernel-hwcaps.sh` script which is a new script introduced about a month ago. 

Fixes 
```bash
make -j$(nproc) O=kernel_build ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-  defconfig sbom
```