### PR TITLE
Support s390 Architecture

### DIFF
--- a/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
+++ b/sbom/sbom/cmd_graph/savedcmd_parser/command_parser_registry.py
@@ -506,7 +506,7 @@ class CommandParserRegistry:
             (re.compile(r"(.*/)?genheaders\b"), _parse_noop),
             (re.compile(r"^(.*/)?mkcpustr\s+>"), _parse_noop),
             (re.compile(r"^(.*/)polgen\b"), _parse_noop),
-            (re.compile(r"make -f .*/arch/x86/Makefile\.postlink"), _parse_noop),
+            (re.compile(r"make -f .*/arch/[^/]+/Makefile\.postlink"), _parse_noop),
             (re.compile(r"^(.*/)?raid6/mktables\s+>"), _parse_noop),
             (re.compile(r"^(.*/)?objtool\b"), _parse_noop),
             (re.compile(r"^(.*/)?module/gen_test_kallsyms.sh"), _parse_noop),

--- a/sbom/sbom/spdx_graph/kernel_file.py
+++ b/sbom/sbom/spdx_graph/kernel_file.py
@@ -261,7 +261,18 @@ def _get_primary_purpose(absolute_path: PathStr) -> SoftwarePurpose | None:
         return "application"
 
     # Executables / machine code
-    if ends_with([".bin", ".elf", "vmlinux", "vmlinux.unstripped", "vmlinuz", "bpfilter_umh"]):
+    if ends_with(
+        [
+            ".bin",
+            ".elf",
+            "vmlinux",
+            "vmlinux.unstripped",
+            "vmlinux.syms",
+            "vmlinuz",
+            "bpfilter_umh",
+            "purgatory",
+        ]
+    ):
         return "executable"
 
     # Kernel modules


### PR DESCRIPTION
Minor changes to support `s390` architecture for `defconfig` and `allmodconfig`:
```
make -j$(nproc) O=kernel_build ARCH=s390 CROSS_COMPILE=s390x-linux-gnu- mrproper defconfig sbom
```
```
make -j$(nproc) O=kernel_build ARCH=s390 CROSS_COMPILE=s390x-linux-gnu- mrproper allmodconfig sbom
```

Tested on https://github.com/torvalds/linux/commit/2d3090a8aeb596a26935db0955d46c9a5db5c6ce

