### PR TITLE
Deprecate File Share Link

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ Copyright (C) 2025 TNG Technology Consulting GmbH
 
 This manually triggered workflow downloads a Linux kernel archive from:
 
-https://fileshare.tngtech.com/d/e69946da808b41f88047/
+~~https://fileshare.tngtech.com/d/e69946da808b41f88047/~~ (the file share link is not available anymore)
 
 The archive includes:
 - The full Linux source tree

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-only OR MIT
 # Copyright (C) 2025 TNG Technology Consulting GmbH
 
-name: Sbom 
+name: '[Deprecated] Sbom'
 
 on:
   workflow_dispatch:
     inputs:
       test_archive:
-        description: Name of the test archive to download from https://fileshare.tngtech.com/d/e69946da808b41f88047/
+        description: Name of the test archive to download from ~~https://fileshare.tngtech.com/d/e69946da808b41f88047/~~ (the file share link is not available anymore)
         default: linux.v6.17.tinyconfig.x86.tar.gz
       src_tree: 
         description: Path to the source tree

--- a/README.md
+++ b/README.md
@@ -9,13 +9,7 @@ A script to generate an SPDX-format Software Bill of Materials (SBOM) for the li
 The eventual goal is to integrate the `sbom/` directory into the `linux/tools/` directory in the official [linux](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git) source tree.
 
 ## How to use
-1. Provide a linux source and object tree, e.g., by downloading precompiled test data from [KernelSbom-TestData](https://fileshare.tngtech.com/d/e69946da808b41f88047/files)
-    ```bash
-    test_archive="linux.v6.17.tinyconfig.x86.tar.gz"
-    curl -L -o "$test_archive" "https://fileshare.tngtech.com/d/e69946da808b41f88047/files/?p=%2F$test_archive&dl=1"
-    tar -xzf "$test_archive"
-    ```
-    or cloning the [linux](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git) repo and building your own config
+1. Provide a linux source and object tree by cloning the [linux](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git) repo and building your own config
     ```bash
     git clone --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     cd linux


### PR DESCRIPTION
Due to company policy the file share had to be cleaned up after 6 months.
